### PR TITLE
feat: Add `track_error` to mirror `track_success`

### DIFF
--- a/ldai/testing/test_tracker.py
+++ b/ldai/testing/test_tracker.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock, call
 
 import pytest
+from time import sleep
 from ldclient import Config, Context, LDClient
 from ldclient.integrations.test_data import TestData
 
@@ -58,6 +59,43 @@ def test_tracks_duration(client: LDClient):
     )
 
     assert tracker.get_summary().duration == 100
+
+
+def test_tracks_duration_of(client: LDClient):
+    context = Context.create('user-key')
+    tracker = LDAIConfigTracker(client, "variation-key", "config-key", context)
+    tracker.track_duration_of(lambda: sleep(0.01))
+
+    calls = client.track.mock_calls  # type: ignore
+
+    assert len(calls) == 1
+    assert calls[0].args[0] == '$ld:ai:duration:total'
+    assert calls[0].args[1] == context
+    assert calls[0].args[2] == {'variationKey': 'variation-key', 'configKey': 'config-key'}
+    assert calls[0].args[3] == pytest.approx(10)
+
+
+def test_tracks_duration_of_with_exception(client: LDClient):
+    context = Context.create('user-key')
+    tracker = LDAIConfigTracker(client, "variation-key", "config-key", context)
+
+    def sleep_and_throw():
+        sleep(0.01)
+        raise ValueError("Something went wrong")
+
+    try:
+        tracker.track_duration_of(sleep_and_throw)
+        assert False, "Should have thrown an exception"
+    except ValueError:
+        pass
+
+    calls = client.track.mock_calls  # type: ignore
+
+    assert len(calls) == 1
+    assert calls[0].args[0] == '$ld:ai:duration:total'
+    assert calls[0].args[1] == context
+    assert calls[0].args[2] == {'variationKey': 'variation-key', 'configKey': 'config-key'}
+    assert calls[0].args[3] == pytest.approx(10)
 
 
 def test_tracks_token_usage(client: LDClient):
@@ -163,6 +201,8 @@ def test_tracks_openai_metrics(client: LDClient):
     tracker.track_openai_metrics(lambda: Result())
 
     calls = [
+        call('$ld:ai:generation', context, {'variationKey': 'variation-key', 'configKey': 'config-key'}, 1),
+        call('$ld:ai:generation:success', context, {'variationKey': 'variation-key', 'configKey': 'config-key'}, 1),
         call('$ld:ai:tokens:total', context, {'variationKey': 'variation-key', 'configKey': 'config-key'}, 330),
         call('$ld:ai:tokens:input', context, {'variationKey': 'variation-key', 'configKey': 'config-key'}, 220),
         call('$ld:ai:tokens:output', context, {'variationKey': 'variation-key', 'configKey': 'config-key'}, 110),
@@ -171,6 +211,29 @@ def test_tracks_openai_metrics(client: LDClient):
     client.track.assert_has_calls(calls, any_order=False)  # type: ignore
 
     assert tracker.get_summary().usage == TokenUsage(330, 220, 110)
+
+
+def test_tracks_openai_metrics_with_exception(client: LDClient):
+    context = Context.create('user-key')
+    tracker = LDAIConfigTracker(client, "variation-key", "config-key", context)
+
+    def raise_exception():
+        raise ValueError("Something went wrong")
+
+    try:
+        tracker.track_openai_metrics(raise_exception)
+        assert False, "Should have thrown an exception"
+    except ValueError:
+        pass
+
+    calls = [
+        call('$ld:ai:generation', context, {'variationKey': 'variation-key', 'configKey': 'config-key'}, 1),
+        call('$ld:ai:generation:error', context, {'variationKey': 'variation-key', 'configKey': 'config-key'}, 1),
+    ]
+
+    client.track.assert_has_calls(calls, any_order=False)  # type: ignore
+
+    assert tracker.get_summary().usage is None
 
 
 @pytest.mark.parametrize(

--- a/ldai/testing/test_tracker.py
+++ b/ldai/testing/test_tracker.py
@@ -72,7 +72,7 @@ def test_tracks_duration_of(client: LDClient):
     assert calls[0].args[0] == '$ld:ai:duration:total'
     assert calls[0].args[1] == context
     assert calls[0].args[2] == {'variationKey': 'variation-key', 'configKey': 'config-key'}
-    assert calls[0].args[3] == pytest.approx(10)
+    assert calls[0].args[3] == pytest.approx(10, rel=10)
 
 
 def test_tracks_duration_of_with_exception(client: LDClient):
@@ -95,7 +95,7 @@ def test_tracks_duration_of_with_exception(client: LDClient):
     assert calls[0].args[0] == '$ld:ai:duration:total'
     assert calls[0].args[1] == context
     assert calls[0].args[2] == {'variationKey': 'variation-key', 'configKey': 'config-key'}
-    assert calls[0].args[3] == pytest.approx(10)
+    assert calls[0].args[3] == pytest.approx(10, rel=10)
 
 
 def test_tracks_token_usage(client: LDClient):

--- a/ldai/testing/test_tracker.py
+++ b/ldai/testing/test_tracker.py
@@ -1,7 +1,7 @@
+from time import sleep
 from unittest.mock import MagicMock, call
 
 import pytest
-from time import sleep
 from ldclient import Config, Context, LDClient
 from ldclient.integrations.test_data import TestData
 

--- a/ldai/tracker.py
+++ b/ldai/tracker.py
@@ -172,6 +172,16 @@ class LDAIConfigTracker:
         """
         Track OpenAI-specific operations.
 
+        This function will track the duration of the operation, the token
+        usage, and the success or error status.
+
+        If the provided function throws, then this method will also throw.
+
+        In the case the provided function throws, this function will record the
+        duration and an error.
+
+        A failed operation will not have any token usage data.
+
         :param func: Function to track.
         :return: Result of the tracked function.
         """
@@ -189,6 +199,10 @@ class LDAIConfigTracker:
     def track_bedrock_converse_metrics(self, res: dict) -> dict:
         """
         Track AWS Bedrock conversation operations.
+
+
+        This function will track the duration of the operation, the token
+        usage, and the success or error status.
 
         :param res: Response dictionary from Bedrock.
         :return: The original response dictionary.

--- a/ldai/tracker.py
+++ b/ldai/tracker.py
@@ -146,6 +146,21 @@ class LDAIConfigTracker:
         self._ld_client.track(
             '$ld:ai:generation', self._context, self.__get_track_data(), 1
         )
+        self._ld_client.track(
+            '$ld:ai:generation:success', self._context, self.__get_track_data(), 1
+        )
+
+    def track_error(self) -> None:
+        """
+        Track an unsuccessful AI generation attempt.
+        """
+        self._summary._success = False
+        self._ld_client.track(
+            '$ld:ai:generation', self._context, self.__get_track_data(), 1
+        )
+        self._ld_client.track(
+            '$ld:ai:generation:error', self._context, self.__get_track_data(), 1
+        )
 
     def track_openai_metrics(self, func):
         """
@@ -170,8 +185,7 @@ class LDAIConfigTracker:
         if status_code == 200:
             self.track_success()
         elif status_code >= 400:
-            # Potentially add error tracking in the future.
-            pass
+            self.track_error()
         if res.get('metrics', {}).get('latencyMs'):
             self.track_duration(res['metrics']['latencyMs'])
         if res.get('usage'):


### PR DESCRIPTION
Additionally, emit new `$ld:ai:generation:(success|error)` events on success or failure.
