### PR TITLE
feat: add tools with instructions and examples to completion and agent configs

### DIFF
--- a/packages/sdk/server-ai/src/ldai/__init__.py
+++ b/packages/sdk/server-ai/src/ldai/__init__.py
@@ -10,8 +10,8 @@ from ldai.models import (  # Deprecated aliases for backward compatibility
     AIAgentConfig, AIAgentConfigDefault, AIAgentConfigRequest,
     AIAgentGraphConfig, AIAgents, AICompletionConfig,
     AICompletionConfigDefault, AIConfig, AIJudgeConfig, AIJudgeConfigDefault,
-    Edge, JudgeConfiguration, LDAIAgent, LDAIAgentConfig, LDAIAgentDefaults,
-    LDMessage, ModelConfig, ProviderConfig)
+    AITool, Edge, JudgeConfiguration, LDAIAgent, LDAIAgentConfig,
+    LDAIAgentDefaults, LDMessage, ModelConfig, ProviderConfig)
 from ldai.providers.types import EvalScore, JudgeResponse
 from ldai.tracker import AIGraphTracker
 
@@ -23,6 +23,7 @@ __all__ = [
     'AIAgents',
     'AIAgentGraphConfig',
     'AIGraphTracker',
+    'AITool',
     'Edge',
     'AICompletionConfig',
     'AICompletionConfigDefault',

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -69,14 +69,14 @@ class LDAIClient:
                 )
                 for tool in variation['tools']
                 if isinstance(tool, dict) and 'key' in tool
-            ] or None
+            ]
 
         config = AICompletionConfig(
             key=key,
             enabled=bool(enabled),
             model=model,
             messages=messages,
-            tools=tools if tools is not None else (default.tools if default.tools else None),
+            tools=tools if tools is not None else default.tools,
             provider=provider,
             tracker=tracker,
             judge_configuration=judge_configuration,
@@ -742,7 +742,7 @@ class LDAIClient:
                 )
                 for tool in variation['tools']
                 if isinstance(tool, dict) and 'key' in tool
-            ] or None
+            ]
 
         return AIAgentConfig(
             key=key,
@@ -750,7 +750,7 @@ class LDAIClient:
             model=model or default.model,
             provider=provider or default.provider,
             instructions=final_instructions,
-            tools=tools if tools is not None else (default.tools if default.tools else None),
+            tools=tools if tools is not None else default.tools,
             tracker=tracker,
             judge_configuration=judge_configuration or default.judge_configuration,
         )

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -11,7 +11,7 @@ from ldai.judge import Judge
 from ldai.models import (AIAgentConfig, AIAgentConfigDefault,
                          AIAgentConfigRequest, AIAgentGraphConfig, AIAgents,
                          AICompletionConfig, AICompletionConfigDefault,
-                         AIJudgeConfig, AIJudgeConfigDefault, Edge,
+                         AIJudgeConfig, AIJudgeConfigDefault, AITool, Edge,
                          JudgeConfiguration, LDMessage, ModelConfig,
                          ProviderConfig)
 from ldai.providers.ai_provider_factory import AIProviderFactory
@@ -706,12 +706,27 @@ class LDAIClient:
         :param variables: Variables for interpolation.
         :return: Configured AIAgentConfig instance.
         """
-        model, provider, messages, instructions, tracker, enabled, judge_configuration, _ = self.__evaluate(
+        model, provider, messages, instructions, tracker, enabled, judge_configuration, variation = self.__evaluate(
             key, context, default.to_dict(), variables
         )
 
         # For agents, prioritize instructions over messages
         final_instructions = instructions if instructions is not None else default.instructions
+
+        # Parse tools from variation data
+        tools = None
+        if 'tools' in variation and isinstance(variation['tools'], list):
+            tools = [
+                AITool(
+                    key=tool['key'],
+                    version=tool.get('version', 0),
+                    instructions=tool.get('instructions'),
+                    examples=tool.get('examples'),
+                    custom_parameters=tool.get('customParameters'),
+                )
+                for tool in variation['tools']
+                if isinstance(tool, dict) and 'key' in tool
+            ] or None
 
         return AIAgentConfig(
             key=key,
@@ -719,6 +734,7 @@ class LDAIClient:
             model=model or default.model,
             provider=provider or default.provider,
             instructions=final_instructions,
+            tools=tools if tools is not None else (default.tools if default.tools else None),
             tracker=tracker,
             judge_configuration=judge_configuration or default.judge_configuration,
         )

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -52,15 +52,31 @@ class LDAIClient:
         default: AICompletionConfigDefault,
         variables: Optional[Dict[str, Any]] = None,
     ) -> AICompletionConfig:
-        model, provider, messages, instructions, tracker, enabled, judge_configuration, _ = self.__evaluate(
+        model, provider, messages, instructions, tracker, enabled, judge_configuration, variation = self.__evaluate(
             key, context, default.to_dict(), variables
         )
+
+        # Parse tools from variation data
+        tools = None
+        if 'tools' in variation and isinstance(variation['tools'], list):
+            tools = [
+                AITool(
+                    key=tool['key'],
+                    version=tool.get('version', 0),
+                    instructions=tool.get('instructions'),
+                    examples=tool.get('examples'),
+                    custom_parameters=tool.get('customParameters'),
+                )
+                for tool in variation['tools']
+                if isinstance(tool, dict) and 'key' in tool
+            ] or None
 
         config = AICompletionConfig(
             key=key,
             enabled=bool(enabled),
             model=model,
             messages=messages,
+            tools=tools if tools is not None else (default.tools if default.tools else None),
             provider=provider,
             tracker=tracker,
             judge_configuration=judge_configuration,

--- a/packages/sdk/server-ai/src/ldai/models.py
+++ b/packages/sdk/server-ai/src/ldai/models.py
@@ -140,6 +140,38 @@ class JudgeConfiguration:
 
 
 # ============================================================================
+# Tool Types
+# ============================================================================
+
+@dataclass(frozen=True)
+class AITool:
+    """
+    Configuration for an AI tool.
+    """
+    key: str
+    version: int
+    instructions: Optional[str] = None
+    examples: Optional[str] = None
+    custom_parameters: Optional[Dict[str, Any]] = None
+
+    def to_dict(self) -> dict:
+        """
+        Render the tool as a dictionary object.
+        """
+        result: Dict[str, Any] = {
+            'key': self.key,
+            'version': self.version,
+        }
+        if self.instructions is not None:
+            result['instructions'] = self.instructions
+        if self.examples is not None:
+            result['examples'] = self.examples
+        if self.custom_parameters is not None:
+            result['customParameters'] = self.custom_parameters
+        return result
+
+
+# ============================================================================
 # Base AI Config Types
 # ============================================================================
 
@@ -249,6 +281,7 @@ class AIAgentConfigDefault(AIConfigDefault):
     Default Agent-specific AI Config with instructions.
     """
     instructions: Optional[str] = None
+    tools: Optional[List[AITool]] = None
     judge_configuration: Optional[JudgeConfiguration] = None
 
     def to_dict(self) -> Dict[str, Any]:
@@ -258,6 +291,8 @@ class AIAgentConfigDefault(AIConfigDefault):
         result = self._base_to_dict()
         if self.instructions is not None:
             result['instructions'] = self.instructions
+        if self.tools is not None:
+            result['tools'] = [tool.to_dict() for tool in self.tools]
         if self.judge_configuration is not None:
             result['judgeConfiguration'] = self.judge_configuration.to_dict()
         return result
@@ -269,6 +304,7 @@ class AIAgentConfig(AIConfig):
     Agent-specific AI Config with instructions.
     """
     instructions: Optional[str] = None
+    tools: Optional[List[AITool]] = None
     judge_configuration: Optional[JudgeConfiguration] = None
 
     def to_dict(self) -> Dict[str, Any]:
@@ -278,6 +314,8 @@ class AIAgentConfig(AIConfig):
         result = self._base_to_dict()
         if self.instructions is not None:
             result['instructions'] = self.instructions
+        if self.tools is not None:
+            result['tools'] = [tool.to_dict() for tool in self.tools]
         if self.judge_configuration is not None:
             result['judgeConfiguration'] = self.judge_configuration.to_dict()
         return result

--- a/packages/sdk/server-ai/src/ldai/models.py
+++ b/packages/sdk/server-ai/src/ldai/models.py
@@ -239,6 +239,7 @@ class AICompletionConfigDefault(AIConfigDefault):
     Default Completion AI Config (default mode).
     """
     messages: Optional[List[LDMessage]] = None
+    tools: Optional[List[AITool]] = None
     judge_configuration: Optional[JudgeConfiguration] = None
 
     def to_dict(self) -> dict:
@@ -247,6 +248,8 @@ class AICompletionConfigDefault(AIConfigDefault):
         """
         result = self._base_to_dict()
         result['messages'] = [message.to_dict() for message in self.messages] if self.messages else None
+        if self.tools is not None:
+            result['tools'] = [tool.to_dict() for tool in self.tools]
         if self.judge_configuration is not None:
             result['judgeConfiguration'] = self.judge_configuration.to_dict()
         return result
@@ -258,6 +261,7 @@ class AICompletionConfig(AIConfig):
     Completion AI Config (default mode).
     """
     messages: Optional[List[LDMessage]] = None
+    tools: Optional[List[AITool]] = None
     judge_configuration: Optional[JudgeConfiguration] = None
 
     def to_dict(self) -> dict:
@@ -266,6 +270,8 @@ class AICompletionConfig(AIConfig):
         """
         result = self._base_to_dict()
         result['messages'] = [message.to_dict() for message in self.messages] if self.messages else None
+        if self.tools is not None:
+            result['tools'] = [tool.to_dict() for tool in self.tools]
         if self.judge_configuration is not None:
             result['judgeConfiguration'] = self.judge_configuration.to_dict()
         return result

--- a/packages/sdk/server-ai/tests/test_tools.py
+++ b/packages/sdk/server-ai/tests/test_tools.py
@@ -1,0 +1,372 @@
+import pytest
+from ldclient import Config, Context, LDClient
+from ldclient.integrations.test_data import TestData
+
+from ldai import LDAIClient, ModelConfig
+from ldai.models import (AIAgentConfigDefault, AICompletionConfigDefault,
+                         AITool)
+
+
+@pytest.fixture
+def td() -> TestData:
+    td = TestData.data_source()
+
+    # Completion config with tools
+    td.update(
+        td.flag('completion-with-tools')
+        .variations(
+            {
+                'model': {'name': 'gpt-4', 'parameters': {'temperature': 0.5}},
+                'provider': {'name': 'openai'},
+                'messages': [{'role': 'system', 'content': 'You are a helpful assistant.'}],
+                'tools': [
+                    {
+                        'key': 'get-customer',
+                        'version': 1,
+                        'instructions': 'Use this tool to look up customer details by email.',
+                        'examples': 'Input: {"email": "jane@example.com"}\nOutput: {"name": "Jane Doe"}',
+                        'customParameters': {'endpoint': '/api/customers'},
+                    },
+                    {
+                        'key': 'search-orders',
+                        'version': 2,
+                        'instructions': 'Search for orders by customer ID.',
+                    },
+                ],
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1},
+            }
+        )
+        .variation_for_all(0)
+    )
+
+    # Agent config with tools
+    td.update(
+        td.flag('agent-with-tools')
+        .variations(
+            {
+                'model': {'name': 'gpt-4', 'parameters': {'temperature': 0.3}},
+                'provider': {'name': 'openai'},
+                'instructions': 'You are a customer support agent for {{company_name}}.',
+                'tools': [
+                    {
+                        'key': 'crm-lookup',
+                        'version': 1,
+                        'instructions': 'Look up customer info in the CRM.',
+                        'examples': 'Input: {"id": "123"}\nOutput: {"name": "John", "plan": "Enterprise"}',
+                        'customParameters': {'timeout': 30},
+                    },
+                ],
+                '_ldMeta': {'enabled': True, 'variationKey': 'agent-v1', 'version': 1, 'mode': 'agent'},
+            }
+        )
+        .variation_for_all(0)
+    )
+
+    # Config with no tools
+    td.update(
+        td.flag('no-tools-config')
+        .variations(
+            {
+                'model': {'name': 'gpt-4'},
+                'messages': [{'role': 'system', 'content': 'Hello'}],
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1},
+            }
+        )
+        .variation_for_all(0)
+    )
+
+    # Config with empty tools array
+    td.update(
+        td.flag('empty-tools-config')
+        .variations(
+            {
+                'model': {'name': 'gpt-4'},
+                'messages': [{'role': 'system', 'content': 'Hello'}],
+                'tools': [],
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1},
+            }
+        )
+        .variation_for_all(0)
+    )
+
+    # Agent config with tools that have minimal fields
+    td.update(
+        td.flag('agent-minimal-tools')
+        .variations(
+            {
+                'instructions': 'Minimal agent.',
+                'tools': [
+                    {'key': 'basic-tool', 'version': 1},
+                ],
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1, 'mode': 'agent'},
+            }
+        )
+        .variation_for_all(0)
+    )
+
+    return td
+
+
+@pytest.fixture
+def client(td: TestData) -> LDClient:
+    config = Config('sdk-key', update_processor_class=td, send_events=False)
+    return LDClient(config=config)
+
+
+@pytest.fixture
+def ldai_client(client: LDClient) -> LDAIClient:
+    return LDAIClient(client)
+
+
+# ============================================================================
+# AITool dataclass tests
+# ============================================================================
+
+def test_ai_tool_to_dict_full():
+    """Test AITool.to_dict() with all fields populated."""
+    tool = AITool(
+        key='get-customer',
+        version=1,
+        instructions='Look up customer by email.',
+        examples='Input: {"email": "a@b.com"}\nOutput: {"name": "Alice"}',
+        custom_parameters={'endpoint': '/api/customers'},
+    )
+
+    result = tool.to_dict()
+
+    assert result == {
+        'key': 'get-customer',
+        'version': 1,
+        'instructions': 'Look up customer by email.',
+        'examples': 'Input: {"email": "a@b.com"}\nOutput: {"name": "Alice"}',
+        'customParameters': {'endpoint': '/api/customers'},
+    }
+
+
+def test_ai_tool_to_dict_minimal():
+    """Test AITool.to_dict() with only required fields."""
+    tool = AITool(key='basic-tool', version=1)
+
+    result = tool.to_dict()
+
+    assert result == {
+        'key': 'basic-tool',
+        'version': 1,
+    }
+    assert 'instructions' not in result
+    assert 'examples' not in result
+    assert 'customParameters' not in result
+
+
+def test_ai_tool_is_frozen():
+    """Test that AITool is immutable."""
+    tool = AITool(key='test', version=1)
+    with pytest.raises(AttributeError):
+        tool.key = 'changed'  # type: ignore[misc]
+
+
+# ============================================================================
+# Completion config with tools tests
+# ============================================================================
+
+def test_completion_config_with_tools(ldai_client: LDAIClient):
+    """Test that completion config correctly parses tools from variation."""
+    context = Context.create('user-key')
+    default = AICompletionConfigDefault(enabled=False, model=ModelConfig('fallback'))
+
+    config = ldai_client.completion_config('completion-with-tools', context, default)
+
+    assert config.enabled is True
+    assert config.tools is not None
+    assert len(config.tools) == 2
+
+    tool1 = config.tools[0]
+    assert tool1.key == 'get-customer'
+    assert tool1.version == 1
+    assert tool1.instructions == 'Use this tool to look up customer details by email.'
+    assert tool1.examples == 'Input: {"email": "jane@example.com"}\nOutput: {"name": "Jane Doe"}'
+    assert tool1.custom_parameters == {'endpoint': '/api/customers'}
+
+    tool2 = config.tools[1]
+    assert tool2.key == 'search-orders'
+    assert tool2.version == 2
+    assert tool2.instructions == 'Search for orders by customer ID.'
+    assert tool2.examples is None
+    assert tool2.custom_parameters is None
+
+
+def test_completion_config_without_tools(ldai_client: LDAIClient):
+    """Test that completion config has no tools when variation has none."""
+    context = Context.create('user-key')
+    default = AICompletionConfigDefault(enabled=False, model=ModelConfig('fallback'))
+
+    config = ldai_client.completion_config('no-tools-config', context, default)
+
+    assert config.enabled is True
+    assert config.tools is None
+
+
+def test_completion_config_empty_tools(ldai_client: LDAIClient):
+    """Test that completion config handles empty tools array."""
+    context = Context.create('user-key')
+    default = AICompletionConfigDefault(enabled=False, model=ModelConfig('fallback'))
+
+    config = ldai_client.completion_config('empty-tools-config', context, default)
+
+    assert config.enabled is True
+    assert config.tools is None
+
+
+def test_completion_config_uses_default_tools(ldai_client: LDAIClient):
+    """Test that completion config falls back to default tools when variation has none."""
+    context = Context.create('user-key')
+    default_tools = [AITool(key='default-tool', version=1, instructions='Default tool')]
+    default = AICompletionConfigDefault(
+        enabled=True,
+        model=ModelConfig('fallback'),
+        tools=default_tools,
+    )
+
+    config = ldai_client.completion_config('no-tools-config', context, default)
+
+    assert config.tools is not None
+    assert len(config.tools) == 1
+    assert config.tools[0].key == 'default-tool'
+
+
+def test_completion_config_default_to_dict_with_tools():
+    """Test AICompletionConfigDefault.to_dict() includes tools."""
+    tools = [
+        AITool(key='tool-a', version=1, instructions='Do A'),
+        AITool(key='tool-b', version=2),
+    ]
+    default = AICompletionConfigDefault(
+        enabled=True,
+        model=ModelConfig('gpt-4'),
+        tools=tools,
+    )
+
+    result = default.to_dict()
+
+    assert 'tools' in result
+    assert len(result['tools']) == 2
+    assert result['tools'][0]['key'] == 'tool-a'
+    assert result['tools'][0]['instructions'] == 'Do A'
+    assert result['tools'][1]['key'] == 'tool-b'
+
+
+def test_completion_config_to_dict_with_tools():
+    """Test AICompletionConfig.to_dict() includes tools."""
+    from ldai.models import AICompletionConfig
+
+    tools = [AITool(key='my-tool', version=3, examples='example text')]
+    config = AICompletionConfig(
+        key='test',
+        enabled=True,
+        tools=tools,
+    )
+
+    result = config.to_dict()
+
+    assert 'tools' in result
+    assert len(result['tools']) == 1
+    assert result['tools'][0]['key'] == 'my-tool'
+    assert result['tools'][0]['version'] == 3
+    assert result['tools'][0]['examples'] == 'example text'
+
+
+# ============================================================================
+# Agent config with tools tests
+# ============================================================================
+
+def test_agent_config_with_tools(ldai_client: LDAIClient):
+    """Test that agent config correctly parses tools from variation."""
+    context = Context.create('user-key')
+    default = AIAgentConfigDefault(enabled=False, model=ModelConfig('fallback'))
+
+    agent = ldai_client.agent_config(
+        'agent-with-tools', context, default, {'company_name': 'Acme Corp'}
+    )
+
+    assert agent.enabled is True
+    assert agent.instructions == 'You are a customer support agent for Acme Corp.'
+    assert agent.tools is not None
+    assert len(agent.tools) == 1
+
+    tool = agent.tools[0]
+    assert tool.key == 'crm-lookup'
+    assert tool.version == 1
+    assert tool.instructions == 'Look up customer info in the CRM.'
+    assert tool.examples == 'Input: {"id": "123"}\nOutput: {"name": "John", "plan": "Enterprise"}'
+    assert tool.custom_parameters == {'timeout': 30}
+
+
+def test_agent_config_minimal_tools(ldai_client: LDAIClient):
+    """Test agent config with tools that have only required fields."""
+    context = Context.create('user-key')
+    default = AIAgentConfigDefault(enabled=False)
+
+    agent = ldai_client.agent_config('agent-minimal-tools', context, default)
+
+    assert agent.enabled is True
+    assert agent.tools is not None
+    assert len(agent.tools) == 1
+    assert agent.tools[0].key == 'basic-tool'
+    assert agent.tools[0].version == 1
+    assert agent.tools[0].instructions is None
+    assert agent.tools[0].examples is None
+    assert agent.tools[0].custom_parameters is None
+
+
+def test_agent_config_uses_default_tools(ldai_client: LDAIClient):
+    """Test that agent config falls back to default tools when variation has none."""
+    context = Context.create('user-key')
+    default_tools = [AITool(key='default-agent-tool', version=1)]
+    default = AIAgentConfigDefault(
+        enabled=True,
+        model=ModelConfig('fallback'),
+        tools=default_tools,
+        instructions='Default instructions',
+    )
+
+    agent = ldai_client.agent_config('non-existent-agent', context, default)
+
+    assert agent.tools is not None
+    assert len(agent.tools) == 1
+    assert agent.tools[0].key == 'default-agent-tool'
+
+
+def test_agent_config_default_to_dict_with_tools():
+    """Test AIAgentConfigDefault.to_dict() includes tools."""
+    tools = [AITool(key='agent-tool', version=1, instructions='Do something')]
+    default = AIAgentConfigDefault(
+        enabled=True,
+        instructions='Be helpful.',
+        tools=tools,
+    )
+
+    result = default.to_dict()
+
+    assert 'tools' in result
+    assert len(result['tools']) == 1
+    assert result['tools'][0]['key'] == 'agent-tool'
+
+
+def test_agent_config_to_dict_with_tools():
+    """Test AIAgentConfig.to_dict() includes tools."""
+    from ldai.models import AIAgentConfig
+
+    tools = [AITool(key='my-tool', version=2)]
+    config = AIAgentConfig(
+        key='test',
+        enabled=True,
+        instructions='Test instructions',
+        tools=tools,
+    )
+
+    result = config.to_dict()
+
+    assert 'tools' in result
+    assert len(result['tools']) == 1
+    assert result['tools'][0]['key'] == 'my-tool'
+    assert result['tools'][0]['version'] == 2

--- a/packages/sdk/server-ai/tests/test_tools.py
+++ b/packages/sdk/server-ai/tests/test_tools.py
@@ -207,14 +207,34 @@ def test_completion_config_without_tools(ldai_client: LDAIClient):
 
 
 def test_completion_config_empty_tools(ldai_client: LDAIClient):
-    """Test that completion config handles empty tools array."""
+    """Test that completion config preserves empty tools array from server."""
     context = Context.create('user-key')
     default = AICompletionConfigDefault(enabled=False, model=ModelConfig('fallback'))
 
     config = ldai_client.completion_config('empty-tools-config', context, default)
 
     assert config.enabled is True
-    assert config.tools is None
+    # An explicit empty tools array from server should be preserved as empty list,
+    # NOT fall back to defaults
+    assert config.tools is not None
+    assert config.tools == []
+
+
+def test_completion_config_empty_tools_no_default_fallback(ldai_client: LDAIClient):
+    """Test that empty tools array from server does NOT fall back to defaults."""
+    context = Context.create('user-key')
+    default_tools = [AITool(key='default-tool', version=1)]
+    default = AICompletionConfigDefault(
+        enabled=False,
+        model=ModelConfig('fallback'),
+        tools=default_tools,
+    )
+
+    config = ldai_client.completion_config('empty-tools-config', context, default)
+
+    assert config.enabled is True
+    # Server sent empty tools=[], so we should honor that, not use defaults
+    assert config.tools == []
 
 
 def test_completion_config_uses_default_tools(ldai_client: LDAIClient):


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Part of a coordinated multi-repo change to add `instructions` and `examples` fields to AI Tools. Companion PRs:
- Gonfalon: https://github.com/launchdarkly/gonfalon/pull/59653
- JS SDK: https://github.com/launchdarkly/js-core/pull/1175

**Describe the solution you've provided**

Adds a new `AITool` dataclass and wires tools through both **completion** and **agent** configurations so the SDK can surface tool metadata (including the new `instructions` and `examples` fields) returned by the LaunchDarkly API.

Changes:
- **`models.py`**: New frozen `AITool` dataclass with `key`, `version`, `instructions`, `examples`, and `custom_parameters` fields. Added `tools: Optional[List[AITool]]` to `AIAgentConfig`, `AIAgentConfigDefault`, `AICompletionConfig`, and `AICompletionConfigDefault`, with serialization support in all `to_dict()` methods.
- **`client.py`**: Both `_completion_config` and `__evaluate_agent` now parse `tools` from the variation dictionary, constructing `AITool` instances. Falls back to `default.tools` when the variation has no tools.
- **`__init__.py`**: Exports `AITool`.
- **`tests/test_tools.py`**: 14 new tests covering tool parsing, serialization, default fallback, and edge cases for both completion and agent configs.

**Updates since last revision**

- Added `tools` field to `AICompletionConfig` and `AICompletionConfigDefault` (previously only on agent configs)
- `_completion_config` in `client.py` now parses tools from variation data, mirroring the agent pattern
- Added comprehensive test suite (`test_tools.py`) — all 91 tests pass (14 new tool tests + 77 existing)

**⚠️ Key items for reviewer**

1. **Duplicated tool-parsing logic**: The tool parsing block in `_completion_config` (lines ~59-72) and `__evaluate_agent` (lines ~733-745) is identical. Consider extracting to a shared helper if this is a concern.
2. **Empty list → None coercion** (`[...] or None`): if all tools fail the filter, the result is `None` rather than `[]`. Verify this is the desired behavior.
3. **Default version=0** (`tool.get('version', 0)`): tools missing a `version` key silently default to 0. Confirm this is acceptable vs raising or skipping.
4. **Fallback expression**: `tools if tools is not None else (default.tools if default.tools else None)` is equivalent to `tools if tools is not None else default.tools` since `default.tools` already defaults to `None`.

**Describe alternatives you've considered**

- Could have parsed tools at the `__evaluate` level (alongside messages, model, etc.) instead of in both `_completion_config` and `__evaluate_agent`. Chose per-method parsing to keep the shared `__evaluate` method unchanged and limit blast radius.

**Additional context**

- [Link to Devin session](https://app.devin.ai/sessions/7c418524ad2545df99a2d00af6885a45)
- Requested by: @ld-paul

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the shape and parsing/serialization of returned config objects (`completion_config`/`agent_config`), which could affect downstream consumers and default/fallback behavior (notably distinguishing missing `tools` from an explicit empty list).
> 
> **Overview**
> Adds a new frozen `AITool` model (including `instructions`, `examples`, and `customParameters`) and wires `tools` through both **completion** and **agent** config types (`AICompletionConfig*`, `AIAgentConfig*`) with `to_dict()` support.
> 
> Updates `LDAIClient` to parse a `tools` array from flag variation payloads in `_completion_config` and `__evaluate_agent`, falling back to `default.tools` only when the server does not send `tools` (while preserving an explicit empty list), and exports `AITool` from `ldai.__init__`.
> 
> Adds `tests/test_tools.py` to cover tool parsing, serialization, default fallback, and empty/missing tool edge cases for both completion and agent configs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0996e4ecb0cd544d1d91f41f37676a5063b60cf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->