### PR TITLE
chore: fix sampled field semantics on JudgeResult

### DIFF
--- a/packages/sdk/server-ai/src/ldai/judge/__init__.py
+++ b/packages/sdk/server-ai/src/ldai/judge/__init__.py
@@ -51,7 +51,7 @@ class Judge:
         :param input_text: The input prompt or question that was provided to the AI
         :param output_text: The AI-generated response to be evaluated
         :param sampling_rate: Sampling rate (0-1) to determine if evaluation should be processed (defaults to 1)
-        :return: Evaluation result; ``sampled=True`` when the evaluation was sampled and run
+        :return: The result of the judge evaluation.
         """
         judge_result = JudgeResult(judge_config_key=self._ai_config.key)
 
@@ -110,7 +110,7 @@ class Judge:
         :param messages: Array of messages representing the conversation history
         :param response: The AI response to be evaluated
         :param sampling_ratio: Sampling ratio (0-1) to determine if evaluation should be processed (defaults to 1)
-        :return: Evaluation result; ``sampled=True`` when the evaluation was sampled and run
+        :return: The result of the judge evaluation.
         """
         input_text = '\r\n'.join([msg.content for msg in messages]) if messages else ''
         output_text = response.message.content

--- a/packages/sdk/server-ai/src/ldai/judge/__init__.py
+++ b/packages/sdk/server-ai/src/ldai/judge/__init__.py
@@ -51,7 +51,7 @@ class Judge:
         :param input_text: The input prompt or question that was provided to the AI
         :param output_text: The AI-generated response to be evaluated
         :param sampling_rate: Sampling rate (0-1) to determine if evaluation should be processed (defaults to 1)
-        :return: Evaluation result; ``sampled=True`` when skipped due to sampling rate
+        :return: Evaluation result; ``sampled=True`` when the evaluation was sampled and run
         """
         judge_result = JudgeResult(judge_config_key=self._ai_config.key)
 
@@ -70,9 +70,9 @@ class Judge:
 
             if random.random() > sampling_rate:
                 log.debug(f'Judge evaluation skipped due to sampling rate: {sampling_rate}')
-                judge_result.sampled = True
                 return judge_result
 
+            judge_result.sampled = True
             messages = self._construct_evaluation_messages(input_text, output_text)
             assert self._evaluation_response_structure is not None
 
@@ -110,7 +110,7 @@ class Judge:
         :param messages: Array of messages representing the conversation history
         :param response: The AI response to be evaluated
         :param sampling_ratio: Sampling ratio (0-1) to determine if evaluation should be processed (defaults to 1)
-        :return: Evaluation result; ``sampled=True`` when skipped due to sampling rate
+        :return: Evaluation result; ``sampled=True`` when the evaluation was sampled and run
         """
         input_text = '\r\n'.join([msg.content for msg in messages]) if messages else ''
         output_text = response.message.content

--- a/packages/sdk/server-ai/src/ldai/providers/types.py
+++ b/packages/sdk/server-ai/src/ldai/providers/types.py
@@ -66,9 +66,9 @@ class JudgeResult:
     success: bool = False
     error_message: Optional[str] = None
     sampled: bool = False  # True when the evaluation was sampled and run
+    metric_key: Optional[str] = None
     score: Optional[float] = None
     reasoning: Optional[str] = None
-    metric_key: Optional[str] = None
 
     def to_dict(self) -> Dict[str, Any]:
         """

--- a/packages/sdk/server-ai/src/ldai/providers/types.py
+++ b/packages/sdk/server-ai/src/ldai/providers/types.py
@@ -65,7 +65,7 @@ class JudgeResult:
     judge_config_key: Optional[str] = None
     success: bool = False
     error_message: Optional[str] = None
-    sampled: bool = False  # True when the judge was skipped due to sampling rate
+    sampled: bool = False  # True when the evaluation was sampled and run
     score: Optional[float] = None
     reasoning: Optional[str] = None
     metric_key: Optional[str] = None

--- a/packages/sdk/server-ai/src/ldai/tracker.py
+++ b/packages/sdk/server-ai/src/ldai/tracker.py
@@ -253,6 +253,9 @@ class LDAIConfigTracker:
         :param judge_result: JudgeResult object containing score, metric key, and success status
         :param graph_key: When set, include ``graphKey`` in the event payload.
         """
+        if not judge_result.sampled:
+            return
+
         if judge_result.success and judge_result.metric_key:
             track_data = self.__get_track_data(graph_key=graph_key)
             if judge_result.judge_config_key:

--- a/packages/sdk/server-ai/tests/test_judge.py
+++ b/packages/sdk/server-ai/tests/test_judge.py
@@ -168,6 +168,7 @@ class TestJudgeEvaluate:
         
         assert isinstance(result, JudgeResult)
         assert result.success is True
+        assert result.sampled is True
         assert result.metric_key == '$ld:ai:judge:relevance'
         assert result.score == 0.85
         assert result.reasoning is not None
@@ -194,6 +195,7 @@ class TestJudgeEvaluate:
 
         assert isinstance(result, JudgeResult)
         assert result.success is True
+        assert result.sampled is True
         assert result.metric_key == '$ld:ai:judge:relevance'
         assert result.score == 0.9
         assert result.reasoning is not None
@@ -288,13 +290,13 @@ class TestJudgeEvaluate:
     async def test_evaluate_respects_sampling_rate(
         self, judge_config_with_key: AIJudgeConfig, tracker: LDAIConfigTracker, mock_runner
     ):
-        """Evaluate should return sampled=True when skipped due to sampling rate."""
+        """Evaluate should return sampled=False when skipped due to sampling rate."""
         judge = Judge(judge_config_with_key, tracker, mock_runner)
 
         result = await judge.evaluate("input", "output", sampling_rate=0.0)
 
         assert isinstance(result, JudgeResult)
-        assert result.sampled is True
+        assert result.sampled is False
         assert result.success is False
         mock_runner.invoke_structured_model.assert_not_called()
 


### PR DESCRIPTION
## Summary
- Inverts the `sampled` field semantics on `JudgeResult`: `sampled=True` now means the evaluation **was** sampled and run; `sampled=False` means it was **not** sampled (bypassed by the sampling rate).
- Previously `sampled=True` indicated the evaluation was *skipped*, which was counterintuitive and inconsistent with the field name.
- Adds an early-return guard in `LDAIConfigTracker.track_judge_result()` to skip tracking when `not result.sampled`.

## Test plan
- [x] Updated existing sampling-rate test to assert `sampled=False` on skip path
- [x] Added `sampled=True` assertions to both successful evaluation tests
- [x] All 114 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a public result-field meaning and alters when judge metrics are emitted, which can affect downstream consumers and analytics even though the code changes are small.
> 
> **Overview**
> `JudgeResult.sampled` semantics are inverted so `sampled=True` now indicates the judge evaluation *ran* (and remains `False` when skipped by `sampling_rate`). `Judge.evaluate()` sets `sampled=True` only on the run path, and `LDAIConfigTracker.track_judge_result()` now early-returns when `not sampled` to avoid emitting metrics for skipped evaluations.
> 
> Tests are updated to assert the new behavior for both success and sampling-skip cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4e949ea16f8ce6d3e886b4536a95ca76bcd3b05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->