### PR TITLE
feat!: rename track_latency to track_duration on AIGraphTracker

### DIFF
--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
@@ -305,7 +305,7 @@ class LangGraphAgentGraphRunner(AgentGraphRunner):
             # Graph-level metrics
             if tracker:
                 tracker.track_path(handler.path)
-                tracker.track_latency(duration)
+                tracker.track_duration(duration)
                 tracker.track_invocation_success()
                 tracker.track_total_tokens(sum_token_usage_from_messages(messages))
 
@@ -325,7 +325,7 @@ class LangGraphAgentGraphRunner(AgentGraphRunner):
                 log.warning(f'LangGraphAgentGraphRunner run failed: {exc}')
             duration = (time.perf_counter_ns() - start_ns) // 1_000_000
             if tracker:
-                tracker.track_latency(duration)
+                tracker.track_duration(duration)
                 tracker.track_invocation_failure()
             return AgentGraphResult(
                 output='',

--- a/packages/ai-providers/server-ai-langchain/tests/test_langgraph_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_langgraph_agent_graph_runner.py
@@ -86,7 +86,7 @@ async def test_langgraph_runner_run_tracks_failure_on_exception():
 
     assert result.metrics.success is False
     tracker.track_invocation_failure.assert_called_once()
-    tracker.track_latency.assert_called_once()
+    tracker.track_duration.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -148,4 +148,4 @@ async def test_langgraph_runner_run_success():
     assert result.metrics.success is True
     tracker.track_path.assert_called_once_with([])
     tracker.track_invocation_success.assert_called_once()
-    tracker.track_latency.assert_called_once()
+    tracker.track_duration.assert_called_once()

--- a/packages/ai-providers/server-ai-langchain/tests/test_tracking_langgraph.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_tracking_langgraph.py
@@ -256,7 +256,7 @@ async def test_tracks_node_and_graph_tokens_on_success():
     ev = _events(mock_ld_client)
     assert ev['$ld:ai:graph:total_tokens'][0][1] == 15
     assert ev['$ld:ai:graph:invocation_success'][0][1] == 1
-    assert '$ld:ai:duration:total' in ev
+    assert '$ld:ai:graph:duration:total' in ev
     assert '$ld:ai:graph:path' in ev
 
 
@@ -428,7 +428,7 @@ async def test_tracks_failure_and_latency_on_model_error():
 
     ev = _events(mock_ld_client)
     assert '$ld:ai:graph:invocation_failure' in ev
-    assert '$ld:ai:duration:total' in ev
+    assert '$ld:ai:graph:duration:total' in ev
     assert '$ld:ai:graph:invocation_success' not in ev
 
 

--- a/packages/ai-providers/server-ai-langchain/tests/test_tracking_langgraph.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_tracking_langgraph.py
@@ -256,7 +256,7 @@ async def test_tracks_node_and_graph_tokens_on_success():
     ev = _events(mock_ld_client)
     assert ev['$ld:ai:graph:total_tokens'][0][1] == 15
     assert ev['$ld:ai:graph:invocation_success'][0][1] == 1
-    assert '$ld:ai:graph:latency' in ev
+    assert '$ld:ai:duration:total' in ev
     assert '$ld:ai:graph:path' in ev
 
 
@@ -428,7 +428,7 @@ async def test_tracks_failure_and_latency_on_model_error():
 
     ev = _events(mock_ld_client)
     assert '$ld:ai:graph:invocation_failure' in ev
-    assert '$ld:ai:graph:latency' in ev
+    assert '$ld:ai:duration:total' in ev
     assert '$ld:ai:graph:invocation_success' not in ev
 
 

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -89,7 +89,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
 
             if tracker:
                 tracker.track_path(path)
-                tracker.track_latency(duration)
+                tracker.track_duration(duration)
                 tracker.track_invocation_success()
                 token_usage = get_ai_usage_from_response(result)
                 if token_usage is not None:
@@ -110,7 +110,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                 log.warning(f'OpenAIAgentGraphRunner run failed: {exc}')
             duration = (time.perf_counter_ns() - start_ns) // 1_000_000
             if tracker:
-                tracker.track_latency(duration)
+                tracker.track_duration(duration)
                 tracker.track_invocation_failure()
             return AgentGraphResult(
                 output='',

--- a/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
@@ -89,7 +89,7 @@ async def test_openai_agent_graph_runner_run_tracks_invocation_failure_on_except
 
     assert result.metrics.success is False
     tracker.track_invocation_failure.assert_called_once()
-    tracker.track_latency.assert_called_once()
+    tracker.track_duration.assert_called_once()
 
 
 @pytest.mark.asyncio
@@ -134,7 +134,7 @@ async def test_openai_agent_graph_runner_run_success():
     assert result.metrics.success is True
     tracker.track_invocation_success.assert_called_once()
     tracker.track_path.assert_called_once()
-    tracker.track_latency.assert_called_once()
+    tracker.track_duration.assert_called_once()
 
     root_tracker = graph.get_node('root-agent').get_config().tracker
     root_tracker.track_duration.assert_called_once()

--- a/packages/ai-providers/server-ai-openai/tests/test_tracking_openai_agents.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_tracking_openai_agents.py
@@ -266,7 +266,7 @@ async def test_tracks_graph_invocation_success_and_latency():
 
     ev = _events(mock_ld_client)
     assert ev['$ld:ai:graph:invocation_success'][0][1] == 1
-    assert '$ld:ai:graph:latency' in ev
+    assert '$ld:ai:duration:total' in ev
     assert '$ld:ai:graph:path' in ev
 
 
@@ -404,7 +404,7 @@ async def test_tracks_failure_and_latency_on_runner_error():
 
     ev = _events(mock_ld_client)
     assert '$ld:ai:graph:invocation_failure' in ev
-    assert '$ld:ai:graph:latency' in ev
+    assert '$ld:ai:duration:total' in ev
     assert '$ld:ai:graph:invocation_success' not in ev
 
 

--- a/packages/ai-providers/server-ai-openai/tests/test_tracking_openai_agents.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_tracking_openai_agents.py
@@ -266,7 +266,7 @@ async def test_tracks_graph_invocation_success_and_latency():
 
     ev = _events(mock_ld_client)
     assert ev['$ld:ai:graph:invocation_success'][0][1] == 1
-    assert '$ld:ai:duration:total' in ev
+    assert '$ld:ai:graph:duration:total' in ev
     assert '$ld:ai:graph:path' in ev
 
 
@@ -404,7 +404,7 @@ async def test_tracks_failure_and_latency_on_runner_error():
 
     ev = _events(mock_ld_client)
     assert '$ld:ai:graph:invocation_failure' in ev
-    assert '$ld:ai:duration:total' in ev
+    assert '$ld:ai:graph:duration:total' in ev
     assert '$ld:ai:graph:invocation_success' not in ev
 
 

--- a/packages/sdk/server-ai/src/ldai/tracker.py
+++ b/packages/sdk/server-ai/src/ldai/tracker.py
@@ -515,7 +515,7 @@ class AIGraphTracker:
         :param duration: Duration in milliseconds.
         """
         self._ld_client.track(
-            "$ld:ai:duration:total",
+            "$ld:ai:graph:duration:total",
             self._context,
             self.__get_track_data(),
             duration,

--- a/packages/sdk/server-ai/src/ldai/tracker.py
+++ b/packages/sdk/server-ai/src/ldai/tracker.py
@@ -508,14 +508,14 @@ class AIGraphTracker:
             1,
         )
 
-    def track_latency(self, duration: int) -> None:
+    def track_duration(self, duration: int) -> None:
         """
-        Track the total latency of graph execution.
+        Track the total duration of graph execution.
 
         :param duration: Duration in milliseconds.
         """
         self._ld_client.track(
-            "$ld:ai:graph:latency",
+            "$ld:ai:duration:total",
             self._context,
             self.__get_track_data(),
             duration,


### PR DESCRIPTION
## Summary
- Rename `AIGraphTracker.track_latency()` → `track_duration()` to align with the updated AIGRAPHTRACK spec
- Update the event key from `$ld:ai:graph:latency` → `$ld:ai:duration:total`
- Update all call sites in OpenAI and LangChain provider packages and their tests

## Test plan
- [x] All server-ai unit tests pass (115 tests)
- [x] All langchain provider tests pass (81 tests)
- [x] All openai provider tests pass (39 tests)
- [x] No remaining references to `track_latency` or `$ld:ai:graph:latency` in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API/event-name change for telemetry: downstream callers and dashboards relying on `track_latency`/`$ld:ai:graph:latency` must migrate to the new method and event key.
> 
> **Overview**
> Updates graph-level tracking to report **duration** instead of **latency** by renaming `AIGraphTracker.track_latency()` to `track_duration()` and changing the emitted event from `$ld:ai:graph:latency` to `$ld:ai:graph:duration:total`.
> 
> All LangGraph and OpenAI agent graph runners (and their unit/integration tests) are updated to call the new method and assert on the new event key for both success and failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f069ef0f9946836c10d8bea25a75416b63bfba47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->