### PR TITLE
fix!: Swap track_metrics_of parameter order to match spec

### DIFF
--- a/packages/sdk/server-ai/src/ldai/judge/__init__.py
+++ b/packages/sdk/server-ai/src/ldai/judge/__init__.py
@@ -75,8 +75,8 @@ class Judge:
             assert self._evaluation_response_structure is not None
 
             response = await tracker.track_metrics_of_async(
-                lambda: self._model_runner.invoke_structured_model(messages, self._evaluation_response_structure),
                 lambda result: result.metrics,
+                lambda: self._model_runner.invoke_structured_model(messages, self._evaluation_response_structure),
             )
 
             parsed = self._parse_evaluation_response(response.data)

--- a/packages/sdk/server-ai/src/ldai/managed_agent.py
+++ b/packages/sdk/server-ai/src/ldai/managed_agent.py
@@ -29,8 +29,8 @@ class ManagedAgent:
         """
         tracker = self._ai_config.create_tracker()
         return await tracker.track_metrics_of_async(
-            lambda: self._agent_runner.run(input),
             lambda result: result.metrics,
+            lambda: self._agent_runner.run(input),
         )
 
     def get_agent_runner(self) -> AgentRunner:

--- a/packages/sdk/server-ai/src/ldai/managed_model.py
+++ b/packages/sdk/server-ai/src/ldai/managed_model.py
@@ -49,8 +49,8 @@ class ManagedModel:
         all_messages = config_messages + self._messages
 
         response = await tracker.track_metrics_of_async(
-            lambda: self._model_runner.invoke_model(all_messages),
             lambda result: result.metrics,
+            lambda: self._model_runner.invoke_model(all_messages),
         )
 
         if (

--- a/packages/sdk/server-ai/src/ldai/tracker.py
+++ b/packages/sdk/server-ai/src/ldai/tracker.py
@@ -262,8 +262,8 @@ class LDAIConfigTracker:
 
     def track_metrics_of(
         self,
-        func: Callable[[], Any],
         metrics_extractor: Callable[[Any], Any],
+        func: Callable[[], Any],
     ) -> Any:
         """
         Track metrics for a synchronous AI operation.
@@ -277,8 +277,8 @@ class LDAIConfigTracker:
 
         For async operations, use :meth:`track_metrics_of_async`.
 
-        :param func: Synchronous callable that runs the operation
         :param metrics_extractor: Function that extracts LDAIMetrics from the operation result
+        :param func: Synchronous callable that runs the operation
         :return: The result of the operation
         """
         start_ns = time.perf_counter_ns()
@@ -294,14 +294,14 @@ class LDAIConfigTracker:
         self.track_duration(duration)
         return self._track_from_metrics_extractor(result, metrics_extractor)
 
-    async def track_metrics_of_async(self, func, metrics_extractor):
+    async def track_metrics_of_async(self, metrics_extractor, func):
         """
         Track metrics for an async AI operation (``func`` is awaited).
 
         Same event semantics as :meth:`track_metrics_of`.
 
-        :param func: Async callable or zero-arg callable that returns an awaitable when called
         :param metrics_extractor: Function that extracts LDAIMetrics from the operation result
+        :param func: Async callable or zero-arg callable that returns an awaitable when called
         :return: The result of the operation
         """
         start_ns = time.perf_counter_ns()

--- a/packages/sdk/server-ai/tests/test_tracker.py
+++ b/packages/sdk/server-ai/tests/test_tracker.py
@@ -531,7 +531,7 @@ def test_config_tracker_track_metrics_of(client: LDClient):
     def extract(r):
         return LDAIMetrics(success=True, usage=TokenUsage(5, 2, 3))
 
-    out = tracker.track_metrics_of(fn, extract)
+    out = tracker.track_metrics_of(extract, fn)
     assert out == "done"
     calls = client.track.mock_calls  # type: ignore
     assert any(c.args[0] == "$ld:ai:generation:success" for c in calls)
@@ -551,7 +551,7 @@ async def test_config_tracker_track_metrics_of_async_passes_graph_key(client: LD
     def extract(r):
         return LDAIMetrics(success=True, usage=TokenUsage(5, 2, 3))
 
-    await tracker.track_metrics_of_async(fn, extract)
+    await tracker.track_metrics_of_async(extract, fn)
     gk_td = {**_base_td(), "graphKey": "gg"}
     calls = client.track.mock_calls  # type: ignore
     assert any(


### PR DESCRIPTION
## Summary

- Swaps the parameter order of `track_metrics_of` and `track_metrics_of_async` so that `metrics_extractor` is first and the operation callable (`func`) is second, matching spec requirement AITRACK 1.1.14.1
- Updates all internal call sites (`managed_agent.py`, `managed_model.py`, `judge/__init__.py`)
- Updates tests in `test_tracker.py`

## Breaking change

Any caller passing positional arguments to `track_metrics_of` or `track_metrics_of_async` must swap their argument order.

## Test plan

- [ ] Existing unit tests in `test_tracker.py` updated and pass
- [ ] Verify no other call sites use the old positional order

Closes AIC-2378

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Breaking API change for any callers using positional arguments to `track_metrics_of`/`track_metrics_of_async`; incorrect ordering would fail at runtime or mis-track metrics.
> 
> **Overview**
> Aligns the public tracking API with the spec by swapping argument order for `LDAIConfigTracker.track_metrics_of` and `track_metrics_of_async` so `metrics_extractor` comes first and the operation callable comes second.
> 
> Updates internal invocation sites in `ManagedModel`, `ManagedAgent`, and `Judge`, and adjusts `test_tracker.py` to use the new positional order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0392d8c99af7e01f54ee1e901200b5db5761c3fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->