### PR TITLE
fix: Add runtime DeprecationWarnings to deprecated methods

### DIFF
--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -1,4 +1,5 @@
 import uuid
+import warnings
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import chevron
@@ -169,6 +170,7 @@ class LDAIClient:
         :param variables: Additional variables for the model configuration.
         :return: The value of the model configuration along with a tracker used for gathering metrics.
         """
+        warnings.warn("config() is deprecated, use completion_config() instead", DeprecationWarning, stacklevel=2)
         return self.completion_config(key, context, default, variables)
 
     def _judge_config(
@@ -417,12 +419,9 @@ class LDAIClient:
         default_ai_provider: Optional[str] = None,
     ) -> Optional[ManagedModel]:
         """
-        .. deprecated:: Use :meth:`create_model` instead.
-
-        Creates and returns a ManagedModel for AI conversations.
-        This method is a deprecated alias for :meth:`create_model`.
+        .. deprecated:: Use :meth:`create_model` instead. This method will be removed in a future version.
         """
-        log.warning('create_chat() is deprecated, use create_model() instead')
+        warnings.warn("create_chat() is deprecated, use create_model() instead", DeprecationWarning, stacklevel=2)
         return await self.create_model(key, context, default, variables, default_ai_provider)
 
     async def create_agent(
@@ -545,6 +544,7 @@ class LDAIClient:
         :param context: The context to evaluate the agent configuration in.
         :return: Configured AIAgentConfig instance.
         """
+        warnings.warn("agent() is deprecated, use agent_config() instead", DeprecationWarning, stacklevel=2)
         return self.agent_config(config.key, context, config.default, config.variables)
 
     def agent_configs(
@@ -791,6 +791,7 @@ class LDAIClient:
         :param context: The context to evaluate the agent configurations in.
         :return: Dictionary mapping agent keys to their AIAgentConfig configurations.
         """
+        warnings.warn("agents() is deprecated, use agent_configs() instead", DeprecationWarning, stacklevel=2)
         return self.agent_configs(agent_configs, context)
 
     def __evaluate(

--- a/packages/sdk/server-ai/src/ldai/tracker.py
+++ b/packages/sdk/server-ai/src/ldai/tracker.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import time
+import warnings
 from dataclasses import dataclass
 from enum import Enum
 from typing import Any, Callable, Dict, Iterable, List, Optional
@@ -391,6 +392,9 @@ class LDAIConfigTracker:
         """
         Track OpenAI-specific operations.
 
+        .. deprecated:: Use :meth:`track_metrics_of` with ``get_ai_metrics_from_response``
+            from ``ldai_openai`` instead. This method will be removed in a future version.
+
         This function will track the duration of the operation, the token
         usage, and the success or error status.
 
@@ -404,6 +408,12 @@ class LDAIConfigTracker:
         :param func: Function to track.
         :return: Result of the tracked function.
         """
+        warnings.warn(
+            "track_openai_metrics is deprecated. Use track_metrics_of with "
+            "get_ai_metrics_from_response from ldai_openai instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         start_ns = time.perf_counter_ns()
         try:
             result = func()

--- a/packages/sdk/server-ai/tests/test_tracker.py
+++ b/packages/sdk/server-ai/tests/test_tracker.py
@@ -294,7 +294,8 @@ def test_tracks_openai_metrics(client: LDClient):
     def get_result():
         return Result()
 
-    tracker.track_openai_metrics(get_result)
+    with pytest.warns(DeprecationWarning, match="track_openai_metrics is deprecated"):
+        tracker.track_openai_metrics(get_result)
 
     calls = [
         call(
@@ -335,11 +336,12 @@ def test_tracks_openai_metrics_with_exception(client: LDClient):
     def raise_exception():
         raise ValueError("Something went wrong")
 
-    try:
-        tracker.track_openai_metrics(raise_exception)
-        assert False, "Should have thrown an exception"
-    except ValueError:
-        pass
+    with pytest.warns(DeprecationWarning, match="track_openai_metrics is deprecated"):
+        try:
+            tracker.track_openai_metrics(raise_exception)
+            assert False, "Should have thrown an exception"
+        except ValueError:
+            pass
 
     calls = [
         call(


### PR DESCRIPTION
## Summary

- `client.py`: `config()`, `create_chat()`, `agent()`, and `agents()` were documented as deprecated in docstrings but emitted no runtime signal (`create_chat` used `log.warning` instead). All four now emit `warnings.warn(..., DeprecationWarning, stacklevel=2)`.
- `tracker.py`: `track_openai_metrics()` now emits a `DeprecationWarning` pointing callers to `track_metrics_of` with `get_ai_metrics_from_response` from `ldai_openai`.
- All deprecated docstrings normalized to the consistent RST form: `.. deprecated:: Use :meth:`X` instead. This method will be removed in a future version.`

This is consistent with the pattern used in `launchdarkly-server-sdk`.

## Test plan

- [ ] `test_tracker.py` updated — both `track_openai_metrics` tests assert `DeprecationWarning` via `pytest.warns`
- [ ] `track_bedrock_converse_metrics` intentionally left unchanged (bedrock package planned separately)

Closes AIC-1663

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged aside from emitting runtime `DeprecationWarning`s, which may surface in caller test output or warning-as-error environments.
> 
> **Overview**
> Adds runtime `DeprecationWarning`s (with `stacklevel=2`) to previously docstring-only deprecated APIs in `LDAIClient` (e.g. `config`, `create_chat`, `agent`, `agents`) and to `LDAIConfigTracker.track_openai_metrics`, replacing the prior log-only signal.
> 
> Updates `test_tracker.py` to assert the new warning behavior via `pytest.warns` while keeping existing tracking semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a018c17c470d836b788857e56afab6e39dc9a786. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->