### PR TITLE
feat: fall back to model.parameters.tools when root tools absent

### DIFF
--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -53,15 +53,14 @@ _DISABLED_AGENT_DEFAULT = AIAgentConfigDefault.disabled()
 _DISABLED_JUDGE_DEFAULT = AIJudgeConfigDefault.disabled()
 
 
-def _parse_tools(tools_data: Optional[Dict[str, Any]], *, warn: bool = True) -> Optional[Dict[str, LDTool]]:
+def _parse_tools(tools_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, LDTool]]:
     """Parse the root-level tools map from a flag variation dict."""
     if not isinstance(tools_data, dict):
         return None
     result: Dict[str, LDTool] = {}
     for tool_name, tool_dict in tools_data.items():
         if not isinstance(tool_dict, dict):
-            if warn:
-                log.warning('Skipping tool "%s": expected a dict, got %s', tool_name, type(tool_dict).__name__)
+            log.warning('Skipping tool "%s": expected a dict, got %s', tool_name, type(tool_dict).__name__)
             continue
         result[tool_name] = LDTool(
             name=tool_dict.get('name', tool_name),
@@ -87,7 +86,7 @@ def _resolve_tools(variation: Dict[str, Any]) -> Optional[Dict[str, LDTool]]:
     if not isinstance(tools_data, dict):
         return None
 
-    return _parse_tools(tools_data, warn=False)
+    return _parse_tools(tools_data)
 
 
 class LDAIClient:

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -56,6 +56,8 @@ _DISABLED_JUDGE_DEFAULT = AIJudgeConfigDefault.disabled()
 def _parse_tools(tools_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, LDTool]]:
     """Parse the root-level tools map from a flag variation dict."""
     if not isinstance(tools_data, dict):
+        if tools_data is not None:
+            log.warning('Skipping tools: expected a dict, got %s', type(tools_data).__name__)
         return None
     result: Dict[str, LDTool] = {}
     for tool_name, tool_dict in tools_data.items():

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -53,14 +53,15 @@ _DISABLED_AGENT_DEFAULT = AIAgentConfigDefault.disabled()
 _DISABLED_JUDGE_DEFAULT = AIJudgeConfigDefault.disabled()
 
 
-def _parse_tools(tools_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, LDTool]]:
+def _parse_tools(tools_data: Optional[Dict[str, Any]], *, warn: bool = True) -> Optional[Dict[str, LDTool]]:
     """Parse the root-level tools map from a flag variation dict."""
     if not isinstance(tools_data, dict):
         return None
-    result = {}
+    result: Dict[str, LDTool] = {}
     for tool_name, tool_dict in tools_data.items():
         if not isinstance(tool_dict, dict):
-            log.warning('Skipping tool "%s": expected a dict, got %s', tool_name, type(tool_dict).__name__)
+            if warn:
+                log.warning('Skipping tool "%s": expected a dict, got %s', tool_name, type(tool_dict).__name__)
             continue
         result[tool_name] = LDTool(
             name=tool_dict.get('name', tool_name),
@@ -86,18 +87,7 @@ def _resolve_tools(variation: Dict[str, Any]) -> Optional[Dict[str, LDTool]]:
     if not isinstance(tools_data, dict):
         return None
 
-    result = {}
-    for tool_name, tool_dict in tools_data.items():
-        if not isinstance(tool_dict, dict):
-            continue
-        result[tool_name] = LDTool(
-            name=tool_dict.get('name', tool_name),
-            description=tool_dict.get('description'),
-            type=tool_dict.get('type'),
-            parameters=tool_dict.get('parameters'),
-            custom_parameters=tool_dict.get('customParameters'),
-        )
-    return result or None
+    return _parse_tools(tools_data, warn=False)
 
 
 class LDAIClient:

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -83,7 +83,10 @@ def _resolve_tools(variation: Dict[str, Any]) -> Optional[Dict[str, LDTool]]:
     if not isinstance(parameters, dict):
         return None
     tools_data = parameters.get('tools')
+    if tools_data is None:
+        return None
     if not isinstance(tools_data, dict):
+        log.warning('Skipping model.parameters.tools: expected a dict, got %s', type(tools_data).__name__)
         return None
 
     return _parse_tools(tools_data)

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -72,6 +72,34 @@ def _parse_tools(tools_data: Optional[Dict[str, Any]]) -> Optional[Dict[str, LDT
     return result or None
 
 
+def _resolve_tools(variation: Dict[str, Any]) -> Optional[Dict[str, LDTool]]:
+    if 'tools' in variation:
+        return _parse_tools(variation['tools'])
+
+    model = variation.get('model')
+    if not isinstance(model, dict):
+        return None
+    parameters = model.get('parameters')
+    if not isinstance(parameters, dict):
+        return None
+    tools_data = parameters.get('tools')
+    if not isinstance(tools_data, dict):
+        return None
+
+    result = {}
+    for tool_name, tool_dict in tools_data.items():
+        if not isinstance(tool_dict, dict):
+            continue
+        result[tool_name] = LDTool(
+            name=tool_dict.get('name', tool_name),
+            description=tool_dict.get('description'),
+            type=tool_dict.get('type'),
+            parameters=tool_dict.get('parameters'),
+            custom_parameters=tool_dict.get('customParameters'),
+        )
+    return result or None
+
+
 class LDAIClient:
     """The LaunchDarkly AI SDK client object."""
 
@@ -117,7 +145,7 @@ class LDAIClient:
         )
 
         evaluator = self._build_evaluator(judge_configuration, context, default_ai_provider, variables)
-        tools = _parse_tools(variation.get('tools'))
+        tools = _resolve_tools(variation)
 
         config = AICompletionConfig(
             key=key,
@@ -946,7 +974,7 @@ class LDAIClient:
         effective_judge_configuration = judge_configuration or JudgeConfiguration(judges=[])
 
         evaluator = self._build_evaluator(effective_judge_configuration, context, default_ai_provider, variables)
-        tools = _parse_tools(variation.get('tools'))
+        tools = _resolve_tools(variation)
 
         return AIAgentConfig(
             key=key,

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -83,10 +83,9 @@ def _resolve_tools(variation: Dict[str, Any]) -> Optional[Dict[str, LDTool]]:
     if not isinstance(parameters, dict):
         return None
     tools_data = parameters.get('tools')
-    if tools_data is None:
-        return None
     if not isinstance(tools_data, dict):
-        log.warning('Skipping model.parameters.tools: expected a dict, got %s', type(tools_data).__name__)
+        if tools_data is not None:
+            log.warning('Skipping model.parameters.tools: expected a dict, got %s', type(tools_data).__name__)
         return None
 
     return _parse_tools(tools_data)

--- a/packages/sdk/server-ai/tests/test_tools.py
+++ b/packages/sdk/server-ai/tests/test_tools.py
@@ -60,6 +60,101 @@ def td() -> TestData:
         .variation_for_all(0)
     )
 
+    td.update(
+        td.flag('completion-tools-in-model-params')
+        .variations(
+            {
+                'model': {
+                    'name': 'gpt-5',
+                    'parameters': {
+                        'temperature': 0.5,
+                        'tools': {
+                            'param-tool': {
+                                'name': 'param-tool',
+                                'type': 'function',
+                                'description': 'A tool from model params',
+                                'parameters': {'type': 'object'},
+                            }
+                        },
+                    },
+                },
+                'messages': [{'role': 'user', 'content': 'Hello'}],
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1},
+            },
+        )
+        .variation_for_all(0)
+    )
+
+    td.update(
+        td.flag('completion-root-and-model-params-tools')
+        .variations(
+            {
+                'model': {
+                    'name': 'gpt-5',
+                    'parameters': {
+                        'tools': {
+                            'model-param-tool': {
+                                'name': 'model-param-tool',
+                                'type': 'function',
+                            }
+                        },
+                    },
+                },
+                'messages': [{'role': 'user', 'content': 'Hello'}],
+                'tools': {
+                    'root-tool': {
+                        'name': 'root-tool',
+                        'type': 'function',
+                    }
+                },
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1},
+            },
+        )
+        .variation_for_all(0)
+    )
+
+    td.update(
+        td.flag('completion-model-params-tools-as-list')
+        .variations(
+            {
+                'model': {
+                    'name': 'gpt-5',
+                    'parameters': {
+                        'tools': [
+                            {'name': 'list-tool', 'type': 'function'},
+                        ],
+                    },
+                },
+                'messages': [{'role': 'user', 'content': 'Hello'}],
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1},
+            },
+        )
+        .variation_for_all(0)
+    )
+
+    td.update(
+        td.flag('completion-model-params-tools-missing-name')
+        .variations(
+            {
+                'model': {
+                    'name': 'gpt-5',
+                    'parameters': {
+                        'tools': {
+                            'valid-tool': {
+                                'name': 'valid-tool',
+                                'type': 'function',
+                            },
+                            'bad-entry': 'not-a-dict',
+                        },
+                    },
+                },
+                'messages': [{'role': 'user', 'content': 'Hello'}],
+                '_ldMeta': {'enabled': True, 'variationKey': 'v1', 'version': 1},
+            },
+        )
+        .variation_for_all(0)
+    )
+
     return td
 
 
@@ -133,3 +228,36 @@ def test_aitool_to_dict_omits_none_fields():
     d = tool.to_dict()
 
     assert d == {'name': 'bare-tool'}
+
+
+def test_completion_config_tools_from_model_params_when_no_root_tools(client, context):
+    result = client.completion_config('completion-tools-in-model-params', context, AICompletionConfigDefault())
+
+    assert result.tools is not None
+    assert 'param-tool' in result.tools
+    tool = result.tools['param-tool']
+    assert tool.name == 'param-tool'
+    assert tool.type == 'function'
+    assert tool.description == 'A tool from model params'
+
+
+def test_completion_config_root_tools_take_priority_over_model_params(client, context):
+    result = client.completion_config('completion-root-and-model-params-tools', context, AICompletionConfigDefault())
+
+    assert result.tools is not None
+    assert 'root-tool' in result.tools
+    assert 'model-param-tool' not in result.tools
+
+
+def test_completion_config_model_params_tools_as_list_returns_none(client, context):
+    result = client.completion_config('completion-model-params-tools-as-list', context, AICompletionConfigDefault())
+
+    assert result.tools is None
+
+
+def test_completion_config_model_params_tools_skips_bad_entries_silently(client, context):
+    result = client.completion_config('completion-model-params-tools-missing-name', context, AICompletionConfigDefault())
+
+    assert result.tools is not None
+    assert 'valid-tool' in result.tools
+    assert 'bad-entry' not in result.tools


### PR DESCRIPTION
## Summary

- Adds `_resolve_tools()` to `client.py` — checks root-level `tools` first, falls back to `model.parameters.tools` for older AI configs
- Root-level `tools` always takes priority when present
- `model.parameters.tools` as a list or non-dict is silently ignored (may be user-defined custom param)
- Entries that are not dicts are silently skipped; valid entries in the same map are still returned

## Background

The LaunchDarkly AI Config API now sends tools in two places: updated configs send them at both root and `model.parameters.tools`; older configs only send them in `model.parameters.tools`. Previously the SDK only read root-level, leaving older configs with no tools.

## Test plan
- [ ] Existing tools tests pass
- [ ] Tools parsed from `model.parameters.tools` when root key is absent
- [ ] Root `tools` wins when both locations are present
- [ ] `model.parameters.tools` as list → `None`
- [ ] Non-dict entries skipped; valid entries in same map returned

Jira: AIC-1935

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to tool parsing/resolution with added tests; risk is limited to how tools are discovered from evaluated flag variations.
> 
> **Overview**
> Adds backward-compatible tool resolution so `completion_config` and `agent_config` can load tools from `model.parameters.tools` when the root-level `tools` field is missing, while keeping root `tools` as the source of truth when both are present.
> 
> Tightens tool parsing with warnings when `tools`/`model.parameters.tools` are present but not dicts, and expands `test_tools.py` coverage for fallback behavior, precedence, list/non-dict rejection, and skipping invalid tool entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1571889ab6eb7f5ce8457291d0e541b224172a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->