### PR TITLE
feat: Update LangChain runners to implement Runner protocol returning RunnerResult

### DIFF
--- a/packages/ai-providers/server-ai-langchain/README.md
+++ b/packages/ai-providers/server-ai-langchain/README.md
@@ -167,38 +167,6 @@ from ldai_langchain.langchain_helper import map_provider_name
 langchain_provider = map_provider_name("gemini")  # Returns "google-genai"
 ```
 
-## API Reference
-
-### LangChainModelRunner
-
-`LangChainModelRunner` implements the `Runner` protocol for LangChain chat models.
-
-#### Constructor
-
-```python
-LangChainModelRunner(llm: BaseChatModel)
-```
-
-#### Methods
-
-- `run(input, output_type=None) -> RunnerResult` — Run the model with a string prompt or list of `LDMessage` objects. Pass `output_type` (JSON schema dict) for structured output.
-- `get_llm() -> BaseChatModel` — Return the underlying LangChain model.
-
-### LangChainAgentRunner
-
-`LangChainAgentRunner` implements the `Runner` protocol for compiled LangChain agent graphs.
-
-#### Constructor
-
-```python
-LangChainAgentRunner(agent: Any)
-```
-
-#### Methods
-
-- `run(input, output_type=None) -> RunnerResult` — Run the agent with the given input. Returns `RunnerResult` with `content`, `metrics` (including `tool_calls`), and `raw`.
-- `get_agent() -> Any` — Return the underlying compiled agent graph.
-
 ## Documentation
 
 For full documentation, please refer to the [LaunchDarkly AI SDK documentation](https://docs.launchdarkly.com/sdk/ai/python).

--- a/packages/ai-providers/server-ai-langchain/README.md
+++ b/packages/ai-providers/server-ai-langchain/README.md
@@ -38,79 +38,68 @@ pip install langchain-google-genai
 import asyncio
 from ldclient import LDClient, Config, Context
 from ldai import init
-from ldai_langchain import LangChainProvider
+from ldai.models import AICompletionConfigDefault, ModelConfig, ProviderConfig
 
 # Initialize LaunchDarkly client
 ld_client = LDClient(Config("your-sdk-key"))
 ai_client = init(ld_client)
 
-# Get AI configuration. Pass a default for improved resiliency when the flag is unavailable or
-# LaunchDarkly is unreachable; omit for a disabled default. Example:
-#   from ldai.models import AICompletionConfigDefault, LDMessage, ModelConfig, ProviderConfig
-#   default = AICompletionConfigDefault(
-#       enabled=True,
-#       model=ModelConfig("gpt-4"),
-#       provider=ProviderConfig("openai"),
-#       messages=[LDMessage(role="system", content="You are a helpful assistant.")]
-#   )
-#   config = ai_client.config("ai-config-key", context, default)
 context = Context.builder("user-123").build()
-config = ai_client.config("ai-config-key", context)
 
 async def main():
-    # Create a LangChain provider from the AI configuration
-    provider = await LangChainProvider.create(config)
+    # Create a ManagedModel backed by the LangChain provider
+    model = await ai_client.create_model(
+        "ai-config-key",
+        context,
+        AICompletionConfigDefault(
+            enabled=True,
+            model=ModelConfig("gpt-4"),
+            provider=ProviderConfig("langchain"),
+        ),
+    )
 
-    # Use the provider to invoke the model
-    from ldai.models import LDMessage
-    messages = [
-        LDMessage(role="system", content="You are a helpful assistant."),
-        LDMessage(role="user", content="Hello, how are you?"),
-    ]
-    
-    response = await provider.invoke_model(messages)
-    print(response.message.content)
+    if model:
+        result = await model.run("Hello, how are you?")
+        print(result.content)
 
 asyncio.run(main())
 ```
 
 ## Usage
 
-### Using LangChainProvider with the Create Factory
+### Using `create_model` (recommended)
 
-The simplest way to use the LangChain provider is with the static `create` factory method, which automatically creates the appropriate LangChain model based on your LaunchDarkly AI configuration:
+The recommended entry point is `LDAIClient.create_model`, which evaluates a
+LaunchDarkly AI config flag, selects the LangChain runner automatically, and
+returns a `ManagedModel` that wraps the runner:
 
 ```python
-from ldai_langchain import LangChainProvider
+model = await ai_client.create_model("ai-config-key", context)
 
-# Create provider from AI configuration
-provider = await LangChainProvider.create(ai_config)
-
-# Invoke the model
-response = await provider.invoke_model(messages)
+if model:
+    result = await model.run("What is feature flagging?")
+    print(result.content)
 ```
 
-### Using an Existing LangChain Model
+### Using the runner directly
 
-If you already have a LangChain model configured, you can use it directly:
+If you need to construct a runner manually (e.g. for testing), you can use
+`LangChainRunnerFactory` from the `ldai_langchain` package:
 
 ```python
 from langchain_openai import ChatOpenAI
-from ldai_langchain import LangChainProvider
+from ldai_langchain import LangChainRunnerFactory
 
-# Create your own LangChain model
 llm = ChatOpenAI(model="gpt-4", temperature=0.7)
+runner = LangChainModelRunner(llm)
 
-# Wrap it with LangChainProvider
-provider = LangChainProvider(llm)
-
-# Use with LaunchDarkly tracking
-response = await provider.invoke_model(messages)
+result = await runner.run("Hello!")
+print(result.content)
 ```
 
 ### Structured Output
 
-The provider supports structured output using LangChain's `with_structured_output`:
+Pass a JSON schema dict as `output_type` to request structured output:
 
 ```python
 response_structure = {
@@ -122,57 +111,49 @@ response_structure = {
     "required": ["sentiment", "confidence"],
 }
 
-result = await provider.invoke_structured_model(messages, response_structure)
-print(result.data)  # {"sentiment": "positive", "confidence": 0.95}
+result = await runner.run(messages, output_type=response_structure)
+print(result.parsed)  # {"sentiment": "positive", "confidence": 0.95}
 ```
 
 ### Tracking Metrics
 
-Use the provider with LaunchDarkly's tracking capabilities:
+`ManagedModel.run()` automatically tracks metrics via the associated
+`LDAIConfigTracker`. For manual tracking, use the tracker directly:
 
 ```python
-# Get the AI config with tracker
-config = ai_client.config("ai-config-key", context)
+model = await ai_client.create_model("ai-config-key", context)
 
-# Create provider
-provider = await LangChainProvider.create(config)
-
-# Track metrics automatically
-async def invoke():
-    return await provider.invoke_model(messages)
-
-response = await config.tracker.track_metrics_of_async(
-    invoke,
-    lambda r: r.metrics
-)
+if model:
+    result = await model.run("Explain feature flags.")
+    # Metrics are tracked automatically; access them via result.metrics
+    print(result.metrics.usage)
 ```
 
 ### Static Utility Methods
 
-The `LangChainProvider` class provides several utility methods:
+The `ldai_langchain` helper module provides several utility functions:
 
 #### Converting Messages
 
 ```python
 from ldai.models import LDMessage
-from ldai_langchain import LangChainProvider
+from ldai_langchain.langchain_helper import convert_messages_to_langchain
 
 messages = [
     LDMessage(role="system", content="You are helpful."),
     LDMessage(role="user", content="Hello!"),
 ]
 
-# Convert to LangChain messages
-langchain_messages = LangChainProvider.convert_messages_to_langchain(messages)
+langchain_messages = convert_messages_to_langchain(messages)
 ```
 
 #### Extracting Metrics
 
 ```python
-from ldai_langchain import LangChainProvider
+from ldai_langchain.langchain_helper import get_ai_metrics_from_response
 
 # After getting a response from LangChain
-metrics = LangChainProvider.get_ai_metrics_from_response(ai_message)
+metrics = get_ai_metrics_from_response(ai_message)
 print(f"Success: {metrics.success}")
 print(f"Tokens used: {metrics.usage.total if metrics.usage else 'N/A'}")
 ```
@@ -180,33 +161,43 @@ print(f"Tokens used: {metrics.usage.total if metrics.usage else 'N/A'}")
 #### Provider Name Mapping
 
 ```python
+from ldai_langchain.langchain_helper import map_provider_name
+
 # Map LaunchDarkly provider names to LangChain provider names
-langchain_provider = LangChainProvider.map_provider("gemini")  # Returns "google-genai"
+langchain_provider = map_provider_name("gemini")  # Returns "google-genai"
 ```
 
 ## API Reference
 
-### LangChainProvider
+### LangChainModelRunner
+
+`LangChainModelRunner` implements the `Runner` protocol for LangChain chat models.
 
 #### Constructor
 
 ```python
-LangChainProvider(llm: BaseChatModel, logger: Optional[Any] = None)
+LangChainModelRunner(llm: BaseChatModel)
 ```
 
-#### Static Methods
+#### Methods
 
-- `create(ai_config: AIConfigKind, logger: Optional[Any] = None) -> LangChainProvider` - Factory method to create a provider from AI configuration
-- `convert_messages_to_langchain(messages: List[LDMessage]) -> List[BaseMessage]` - Convert LaunchDarkly messages to LangChain messages
-- `get_ai_metrics_from_response(response: AIMessage) -> LDAIMetrics` - Extract metrics from a LangChain response
-- `map_provider(ld_provider_name: str) -> str` - Map LaunchDarkly provider names to LangChain names
-- `create_langchain_model(ai_config: AIConfigKind) -> BaseChatModel` - Create a LangChain model from AI configuration
+- `run(input, output_type=None) -> RunnerResult` — Run the model with a string prompt or list of `LDMessage` objects. Pass `output_type` (JSON schema dict) for structured output.
+- `get_llm() -> BaseChatModel` — Return the underlying LangChain model.
 
-#### Instance Methods
+### LangChainAgentRunner
 
-- `invoke_model(messages: List[LDMessage]) -> ChatResponse` - Invoke the model with messages
-- `invoke_structured_model(messages: List[LDMessage], response_structure: Dict[str, Any]) -> StructuredResponse` - Invoke with structured output
-- `get_chat_model() -> BaseChatModel` - Get the underlying LangChain model
+`LangChainAgentRunner` implements the `Runner` protocol for compiled LangChain agent graphs.
+
+#### Constructor
+
+```python
+LangChainAgentRunner(agent: Any)
+```
+
+#### Methods
+
+- `run(input, output_type=None) -> RunnerResult` — Run the agent with the given input. Returns `RunnerResult` with `content`, `metrics` (including `tool_calls`), and `raw`.
+- `get_agent() -> Any` — Return the underlying compiled agent graph.
 
 ## Documentation
 

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
@@ -54,11 +54,13 @@ class LangChainAgentRunner(Runner):
             })
             messages = result.get("messages", [])
             output = extract_last_message_content(messages)
+            tool_calls = _extract_tool_calls(messages)
             return RunnerResult(
                 content=output,
                 metrics=LDAIMetrics(
                     success=True,
                     usage=sum_token_usage_from_messages(messages),
+                    tool_calls=tool_calls if tool_calls else None,
                 ),
                 raw=result,
             )
@@ -72,3 +74,27 @@ class LangChainAgentRunner(Runner):
     def get_agent(self) -> Any:
         """Return the underlying compiled LangChain agent."""
         return self._agent
+
+
+def _extract_tool_calls(messages: Any) -> list:
+    """
+    Extract tool-call names from a LangChain agent's message list.
+
+    LangChain's ``AIMessage`` exposes ``.tool_calls`` as a list of dicts
+    (``{'name': ..., 'args': ..., 'id': ...}``). Some providers emit
+    OpenAI-style objects with ``.function.name`` instead; handle both shapes.
+    """
+    tool_calls: list = []
+    for msg in messages or []:
+        msg_tool_calls = getattr(msg, 'tool_calls', None)
+        if not msg_tool_calls:
+            continue
+        for tc in msg_tool_calls:
+            if isinstance(tc, dict) and 'name' in tc:
+                tool_calls.append(tc['name'])
+            else:
+                fn = getattr(tc, 'function', None)
+                name = getattr(fn, 'name', None) if fn is not None else None
+                if name:
+                    tool_calls.append(name)
+    return tool_calls

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
@@ -1,30 +1,31 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 from ldai import log
+from ldai.providers.runner import Runner
 from ldai.providers.types import LDAIMetrics, RunnerResult
 
 from ldai_langchain.langchain_helper import (
     extract_last_message_content,
-    get_tool_calls_from_response,
     sum_token_usage_from_messages,
 )
 
 
-class LangChainAgentRunner:
+class LangChainAgentRunner(Runner):
     """
     CAUTION:
     This feature is experimental and should NOT be considered ready for production use.
     It may change or be removed without notice and is not subject to backwards
     compatibility guarantees.
 
-    Runner implementation for a single LangChain agent.
+    Runner implementation for LangChain agents.
 
     Wraps a compiled LangChain agent graph (from ``langchain.agents.create_agent``)
     and delegates execution to it. Tool calling and loop management are handled
     internally by the graph.
-    Returned by ``LangChainRunnerFactory.create_agent(config, tools)``.
+    Returned by LangChainRunnerFactory.create_agent(config, tools).
 
-    Implements the unified :class:`~ldai.providers.runner.Runner` protocol.
+    Implements the unified :class:`~ldai.providers.runner.Runner` protocol via
+    :meth:`run`.
     """
 
     def __init__(self, agent: Any):
@@ -36,7 +37,7 @@ class LangChainAgentRunner:
         output_type: Optional[Dict[str, Any]] = None,
     ) -> RunnerResult:
         """
-        Run the agent with the given input.
+        Run the agent with the given input string.
 
         Delegates to the compiled LangChain agent, which handles
         the tool-calling loop internally.
@@ -45,21 +46,19 @@ class LangChainAgentRunner:
         :param output_type: Reserved for future structured output support;
             currently ignored.
         :return: :class:`RunnerResult` with ``content``, ``raw`` response, and
-            metrics including aggregated token usage and observed ``tool_calls``.
+            aggregated metrics.
         """
         try:
             result = await self._agent.ainvoke({
                 "messages": [{"role": "user", "content": str(input)}]
             })
-            messages: List[Any] = result.get("messages", [])
-            content = extract_last_message_content(messages)
-            tool_calls = self._extract_tool_calls(messages)
+            messages = result.get("messages", [])
+            output = extract_last_message_content(messages)
             return RunnerResult(
-                content=content,
+                content=output,
                 metrics=LDAIMetrics(
                     success=True,
                     usage=sum_token_usage_from_messages(messages),
-                    tool_calls=tool_calls if tool_calls else None,
                 ),
                 raw=result,
             )
@@ -69,14 +68,6 @@ class LangChainAgentRunner:
                 content="",
                 metrics=LDAIMetrics(success=False, usage=None),
             )
-
-    @staticmethod
-    def _extract_tool_calls(messages: List[Any]) -> List[str]:
-        """Collect tool call names from all messages in the agent output."""
-        names: List[str] = []
-        for msg in messages:
-            names.extend(get_tool_calls_from_response(msg))
-        return names
 
     def get_agent(self) -> Any:
         """Return the underlying compiled LangChain agent."""

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
@@ -1,64 +1,82 @@
-from typing import Any
+from typing import Any, Dict, List, Optional
 
 from ldai import log
-from ldai.providers import AgentResult, AgentRunner
-from ldai.providers.types import LDAIMetrics
+from ldai.providers.types import LDAIMetrics, RunnerResult
 
 from ldai_langchain.langchain_helper import (
     extract_last_message_content,
+    get_tool_calls_from_response,
     sum_token_usage_from_messages,
 )
 
 
-class LangChainAgentRunner(AgentRunner):
+class LangChainAgentRunner:
     """
     CAUTION:
     This feature is experimental and should NOT be considered ready for production use.
     It may change or be removed without notice and is not subject to backwards
     compatibility guarantees.
 
-    AgentRunner implementation for LangChain.
+    Runner implementation for a single LangChain agent.
 
     Wraps a compiled LangChain agent graph (from ``langchain.agents.create_agent``)
     and delegates execution to it. Tool calling and loop management are handled
     internally by the graph.
-    Returned by LangChainRunnerFactory.create_agent(config, tools).
+    Returned by ``LangChainRunnerFactory.create_agent(config, tools)``.
+
+    Implements the unified :class:`~ldai.providers.runner.Runner` protocol.
     """
 
     def __init__(self, agent: Any):
         self._agent = agent
 
-    async def run(self, input: Any) -> AgentResult:
+    async def run(
+        self,
+        input: Any,
+        output_type: Optional[Dict[str, Any]] = None,
+    ) -> RunnerResult:
         """
-        Run the agent with the given input string.
+        Run the agent with the given input.
 
         Delegates to the compiled LangChain agent, which handles
         the tool-calling loop internally.
 
         :param input: The user prompt or input to the agent
-        :return: AgentResult with output, raw response, and aggregated metrics
+        :param output_type: Reserved for future structured output support;
+            currently ignored.
+        :return: :class:`RunnerResult` with ``content``, ``raw`` response, and
+            metrics including aggregated token usage and observed ``tool_calls``.
         """
         try:
             result = await self._agent.ainvoke({
                 "messages": [{"role": "user", "content": str(input)}]
             })
-            messages = result.get("messages", [])
-            output = extract_last_message_content(messages)
-            return AgentResult(
-                output=output,
-                raw=result,
+            messages: List[Any] = result.get("messages", [])
+            content = extract_last_message_content(messages)
+            tool_calls = self._extract_tool_calls(messages)
+            return RunnerResult(
+                content=content,
                 metrics=LDAIMetrics(
                     success=True,
                     usage=sum_token_usage_from_messages(messages),
+                    tool_calls=tool_calls if tool_calls else None,
                 ),
+                raw=result,
             )
         except Exception as error:
             log.warning(f"LangChain agent run failed: {error}")
-            return AgentResult(
-                output="",
-                raw=None,
+            return RunnerResult(
+                content="",
                 metrics=LDAIMetrics(success=False, usage=None),
             )
+
+    @staticmethod
+    def _extract_tool_calls(messages: List[Any]) -> List[str]:
+        """Collect tool call names from all messages in the agent output."""
+        names: List[str] = []
+        for msg in messages:
+            names.extend(get_tool_calls_from_response(msg))
+        return names
 
     def get_agent(self) -> Any:
         """Return the underlying compiled LangChain agent."""

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
@@ -56,6 +56,8 @@ class LangChainModelRunner(Runner):
             return await self._run_structured(messages, output_type)
         return await self._run_completion(messages)
 
+    # convert_messages_to_langchain only accepts List[LDMessage]; _coerce_input
+    # normalizes a bare string to [LDMessage(role='user', ...)] before that step.
     @staticmethod
     def _coerce_input(input: Any) -> List[LDMessage]:
         if isinstance(input, str):
@@ -116,7 +118,13 @@ class LangChainModelRunner(Runner):
             raw_content = ''
             if raw_response is not None:
                 if hasattr(raw_response, 'content'):
-                    raw_content = raw_response.content or ''
+                    if isinstance(raw_response.content, str):
+                        raw_content = raw_response.content
+                    else:
+                        log.warning(
+                            f'Multimodal response not supported in structured mode. '
+                            f'Content type: {type(raw_response.content)}, Content: {raw_response.content}'
+                        )
                 usage = get_ai_usage_from_response(raw_response)
 
             if response.get('parsing_error'):

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List, Optional
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import BaseMessage
 from ldai import LDMessage, log
+from ldai.providers.runner import Runner
 from ldai.providers.types import LDAIMetrics, RunnerResult
 
 from ldai_langchain.langchain_helper import (
@@ -12,12 +13,12 @@ from ldai_langchain.langchain_helper import (
 )
 
 
-class LangChainModelRunner:
+class LangChainModelRunner(Runner):
     """
     Runner implementation for LangChain chat models.
 
     Holds a fully-configured BaseChatModel.
-    Returned by ``LangChainRunnerFactory.create_model(config)``.
+    Returned by LangChainRunnerFactory.create_model(config).
 
     Implements the unified :class:`~ldai.providers.runner.Runner` protocol via
     :meth:`run`.
@@ -45,11 +46,12 @@ class LangChainModelRunner:
         :param input: A string prompt or a list of :class:`LDMessage` objects
         :param output_type: Optional JSON schema dict requesting structured output.
             When provided, ``parsed`` on the returned :class:`RunnerResult` is
-            populated with the structured data.
+            populated with the parsed JSON document.
         :return: :class:`RunnerResult` containing ``content``, ``metrics``,
             ``raw`` and (when ``output_type`` is set) ``parsed``.
         """
         messages = self._coerce_input(input)
+
         if output_type is not None:
             return await self._run_structured(messages, output_type)
         return await self._run_completion(messages)
@@ -93,11 +95,13 @@ class LangChainModelRunner:
             )
 
     async def _run_structured(
-        self, messages: List[LDMessage], response_structure: Dict[str, Any]
+        self,
+        messages: List[LDMessage],
+        output_type: Dict[str, Any],
     ) -> RunnerResult:
         try:
             langchain_messages = convert_messages_to_langchain(messages)
-            structured_llm = self._llm.with_structured_output(response_structure, include_raw=True)
+            structured_llm = self._llm.with_structured_output(output_type, include_raw=True)
             response = await structured_llm.ainvoke(langchain_messages)
 
             if not isinstance(response, dict):
@@ -108,8 +112,12 @@ class LangChainModelRunner:
                 )
 
             raw_response = response.get('raw')
-            usage = get_ai_usage_from_response(raw_response) if raw_response is not None else None
-            raw_content = raw_response.content if raw_response is not None and hasattr(raw_response, 'content') else ''
+            usage = None
+            raw_content = ''
+            if raw_response is not None:
+                if hasattr(raw_response, 'content'):
+                    raw_content = raw_response.content or ''
+                usage = get_ai_usage_from_response(raw_response)
 
             if response.get('parsing_error'):
                 log.warning('LangChain structured model invocation had a parsing error')
@@ -132,4 +140,3 @@ class LangChainModelRunner:
                 content='',
                 metrics=LDAIMetrics(success=False, usage=None),
             )
-

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
@@ -1,10 +1,9 @@
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import BaseMessage
 from ldai import LDMessage, log
-from ldai.providers.model_runner import ModelRunner
-from ldai.providers.types import LDAIMetrics, ModelResponse, StructuredResponse
+from ldai.providers.types import LDAIMetrics, RunnerResult
 
 from ldai_langchain.langchain_helper import (
     convert_messages_to_langchain,
@@ -13,12 +12,15 @@ from ldai_langchain.langchain_helper import (
 )
 
 
-class LangChainModelRunner(ModelRunner):
+class LangChainModelRunner:
     """
-    ModelRunner implementation for LangChain.
+    Runner implementation for LangChain chat models.
 
     Holds a fully-configured BaseChatModel.
-    Returned by LangChainConnector.create_model(config).
+    Returned by ``LangChainRunnerFactory.create_model(config)``.
+
+    Implements the unified :class:`~ldai.providers.runner.Runner` protocol via
+    :meth:`run`.
     """
 
     def __init__(self, llm: BaseChatModel):
@@ -32,13 +34,37 @@ class LangChainModelRunner(ModelRunner):
         """
         return self._llm
 
-    async def invoke_model(self, messages: List[LDMessage]) -> ModelResponse:
+    async def run(
+        self,
+        input: Any,
+        output_type: Optional[Dict[str, Any]] = None,
+    ) -> RunnerResult:
         """
-        Invoke the LangChain model with an array of messages.
+        Run the LangChain model with the given input.
 
-        :param messages: Array of LDMessage objects representing the conversation
-        :return: ModelResponse containing the model's response and metrics
+        :param input: A string prompt or a list of :class:`LDMessage` objects
+        :param output_type: Optional JSON schema dict requesting structured output.
+            When provided, ``parsed`` on the returned :class:`RunnerResult` is
+            populated with the structured data.
+        :return: :class:`RunnerResult` containing ``content``, ``metrics``,
+            ``raw`` and (when ``output_type`` is set) ``parsed``.
         """
+        messages = self._coerce_input(input)
+        if output_type is not None:
+            return await self._run_structured(messages, output_type)
+        return await self._run_completion(messages)
+
+    @staticmethod
+    def _coerce_input(input: Any) -> List[LDMessage]:
+        if isinstance(input, str):
+            return [LDMessage(role='user', content=input)]
+        if isinstance(input, list):
+            return input
+        raise TypeError(
+            f"Unsupported input type for LangChainModelRunner.run: {type(input).__name__}"
+        )
+
+    async def _run_completion(self, messages: List[LDMessage]) -> RunnerResult:
         try:
             langchain_messages = convert_messages_to_langchain(messages)
             response: BaseMessage = await self._llm.ainvoke(langchain_messages)
@@ -52,36 +78,23 @@ class LangChainModelRunner(ModelRunner):
                     f'Multimodal response not supported, expecting a string. '
                     f'Content type: {type(response.content)}, Content: {response.content}'
                 )
-                metrics = LDAIMetrics(success=False, usage=metrics.usage)
+                return RunnerResult(
+                    content='',
+                    metrics=LDAIMetrics(success=False, usage=metrics.usage),
+                    raw=response,
+                )
 
-            return ModelResponse(
-                message=LDMessage(role='assistant', content=content),
-                metrics=metrics,
-            )
+            return RunnerResult(content=content, metrics=metrics, raw=response)
         except Exception as error:
             log.warning(f'LangChain model invocation failed: {error}')
-            return ModelResponse(
-                message=LDMessage(role='assistant', content=''),
+            return RunnerResult(
+                content='',
                 metrics=LDAIMetrics(success=False, usage=None),
             )
 
-    async def invoke_structured_model(
-        self,
-        messages: List[LDMessage],
-        response_structure: Dict[str, Any],
-    ) -> StructuredResponse:
-        """
-        Invoke the LangChain model with structured output support.
-
-        :param messages: Array of LDMessage objects representing the conversation
-        :param response_structure: Dictionary defining the output structure
-        :return: StructuredResponse containing the structured data
-        """
-        structured_response = StructuredResponse(
-            data={},
-            raw_response='',
-            metrics=LDAIMetrics(success=False, usage=None),
-        )
+    async def _run_structured(
+        self, messages: List[LDMessage], response_structure: Dict[str, Any]
+    ) -> RunnerResult:
         try:
             langchain_messages = convert_messages_to_langchain(messages)
             structured_llm = self._llm.with_structured_output(response_structure, include_raw=True)
@@ -89,21 +102,34 @@ class LangChainModelRunner(ModelRunner):
 
             if not isinstance(response, dict):
                 log.warning(f'Structured output did not return a dict. Got: {type(response)}')
-                return structured_response
+                return RunnerResult(
+                    content='',
+                    metrics=LDAIMetrics(success=False, usage=None),
+                )
 
             raw_response = response.get('raw')
-            if raw_response is not None:
-                if hasattr(raw_response, 'content'):
-                    structured_response.raw_response = raw_response.content
-                structured_response.metrics.usage = get_ai_usage_from_response(raw_response)
+            usage = get_ai_usage_from_response(raw_response) if raw_response is not None else None
+            raw_content = raw_response.content if raw_response is not None and hasattr(raw_response, 'content') else ''
 
             if response.get('parsing_error'):
                 log.warning('LangChain structured model invocation had a parsing error')
-                return structured_response
+                return RunnerResult(
+                    content=raw_content,
+                    metrics=LDAIMetrics(success=False, usage=usage),
+                    raw=raw_response,
+                )
 
-            structured_response.metrics.success = True
-            structured_response.data = response.get('parsed') or {}
-            return structured_response
+            parsed = response.get('parsed') or {}
+            return RunnerResult(
+                content=raw_content,
+                metrics=LDAIMetrics(success=True, usage=usage),
+                raw=raw_response,
+                parsed=parsed,
+            )
         except Exception as error:
             log.warning(f'LangChain structured model invocation failed: {error}')
-            return structured_response
+            return RunnerResult(
+                content='',
+                metrics=LDAIMetrics(success=False, usage=None),
+            )
+

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
@@ -329,8 +329,10 @@ class LangGraphAgentGraphRunner(AgentGraphRunner):
             messages = result.get('messages', [])
             output = extract_last_message_content(messages)
 
-            # Flush per-node metrics to LD trackers
-            all_eval_results = await handler.flush(self._graph, pending_eval_tasks)
+            # Flush per-node metrics to LD trackers; eval results are tracked
+            # internally and intentionally not exposed on AgentGraphResult here
+            # — judge dispatch is the managed layer's responsibility.
+            await handler.flush(self._graph, pending_eval_tasks)
 
             tracker.track_path(handler.path)
             tracker.track_duration(duration)
@@ -341,7 +343,6 @@ class LangGraphAgentGraphRunner(AgentGraphRunner):
                 output=output,
                 raw=result,
                 metrics=LDAIMetrics(success=True),
-                evaluations=all_eval_results,
             )
 
         except Exception as exc:

--- a/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
@@ -219,8 +219,8 @@ class TestMapProvider:
         assert map_provider('unknown') == 'unknown'
 
 
-class TestInvokeModel:
-    """Tests for invoke_model instance method."""
+class TestRunCompletion:
+    """Tests for the unified run() method (chat-completion path)."""
 
     @pytest.fixture
     def mock_llm(self):
@@ -235,10 +235,10 @@ class TestInvokeModel:
         provider = LangChainModelRunner(mock_llm)
 
         messages = [LDMessage(role='user', content='Hello')]
-        result = await provider.invoke_model(messages)
+        result = await provider.run(messages)
 
         assert result.metrics.success is True
-        assert result.message.content == 'Test response'
+        assert result.content == 'Test response'
 
     @pytest.mark.asyncio
     async def test_returns_success_false_for_non_string_content_and_logs_warning(self, mock_llm):
@@ -248,10 +248,10 @@ class TestInvokeModel:
         provider = LangChainModelRunner(mock_llm)
 
         messages = [LDMessage(role='user', content='Hello')]
-        result = await provider.invoke_model(messages)
+        result = await provider.run(messages)
 
         assert result.metrics.success is False
-        assert result.message.content == ''
+        assert result.content == ''
 
     @pytest.mark.asyncio
     async def test_returns_success_false_when_model_invocation_throws_error(self, mock_llm):
@@ -261,15 +261,14 @@ class TestInvokeModel:
         provider = LangChainModelRunner(mock_llm)
 
         messages = [LDMessage(role='user', content='Hello')]
-        result = await provider.invoke_model(messages)
+        result = await provider.run(messages)
 
         assert result.metrics.success is False
-        assert result.message.content == ''
-        assert result.message.role == 'assistant'
+        assert result.content == ''
 
 
-class TestInvokeStructuredModel:
-    """Tests for invoke_structured_model instance method."""
+class TestRunStructured:
+    """Tests for the unified run() method (structured-output path)."""
 
     @pytest.fixture
     def mock_llm(self):
@@ -288,10 +287,10 @@ class TestInvokeStructuredModel:
 
         messages = [LDMessage(role='user', content='Hello')]
         response_structure = {'type': 'object', 'properties': {}}
-        result = await provider.invoke_structured_model(messages, response_structure)
+        result = await provider.run(messages, output_type=response_structure)
 
         assert result.metrics.success is True
-        assert result.data == parsed_data
+        assert result.parsed == parsed_data
 
     @pytest.mark.asyncio
     async def test_returns_success_false_when_structured_model_invocation_throws_error(self, mock_llm):
@@ -304,11 +303,11 @@ class TestInvokeStructuredModel:
 
         messages = [LDMessage(role='user', content='Hello')]
         response_structure = {'type': 'object', 'properties': {}}
-        result = await provider.invoke_structured_model(messages, response_structure)
+        result = await provider.run(messages, output_type=response_structure)
 
         assert result.metrics.success is False
-        assert result.data == {}
-        assert result.raw_response == ''
+        assert result.parsed is None
+        assert result.content == ''
         assert result.metrics.usage is None
 
 
@@ -464,7 +463,7 @@ class TestLangChainAgentRunner:
 
     @pytest.mark.asyncio
     async def test_runs_agent_and_returns_result(self):
-        """Should return AgentResult with the last message content from the graph."""
+        """Should return RunnerResult with the last message content from the graph."""
         from ldai_langchain import LangChainAgentRunner
 
         final_msg = AIMessage(content="The answer is 42.")
@@ -474,7 +473,7 @@ class TestLangChainAgentRunner:
         runner = LangChainAgentRunner(mock_agent)
         result = await runner.run("What is the answer?")
 
-        assert result.output == "The answer is 42."
+        assert result.content == "The answer is 42."
         assert result.metrics.success is True
         mock_agent.ainvoke.assert_called_once_with(
             {"messages": [{"role": "user", "content": "What is the answer?"}]}
@@ -496,7 +495,7 @@ class TestLangChainAgentRunner:
         runner = LangChainAgentRunner(mock_agent)
         result = await runner.run("Hello")
 
-        assert result.output == "final answer"
+        assert result.content == "final answer"
         assert result.metrics.success is True
         assert result.metrics.usage is not None
         assert result.metrics.usage.total == 30
@@ -505,7 +504,7 @@ class TestLangChainAgentRunner:
 
     @pytest.mark.asyncio
     async def test_returns_failure_when_exception_thrown(self):
-        """Should return unsuccessful AgentResult when exception is thrown."""
+        """Should return unsuccessful RunnerResult when exception is thrown."""
         from ldai_langchain import LangChainAgentRunner
 
         mock_agent = MagicMock()
@@ -514,7 +513,7 @@ class TestLangChainAgentRunner:
         runner = LangChainAgentRunner(mock_agent)
         result = await runner.run("Hello")
 
-        assert result.output == ""
+        assert result.content == ""
         assert result.metrics.success is False
 
 

--- a/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
@@ -220,7 +220,7 @@ class TestMapProvider:
 
 
 class TestRunCompletion:
-    """Tests for the unified run() method (chat-completion path)."""
+    """Tests for run() without structured output."""
 
     @pytest.fixture
     def mock_llm(self):
@@ -268,7 +268,7 @@ class TestRunCompletion:
 
 
 class TestRunStructured:
-    """Tests for the unified run() method (structured-output path)."""
+    """Tests for run() with structured output."""
 
     @pytest.fixture
     def mock_llm(self):
@@ -307,7 +307,7 @@ class TestRunStructured:
 
         assert result.metrics.success is False
         assert result.parsed is None
-        assert result.content == ''
+        assert result.raw is None
         assert result.metrics.usage is None
 
 

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -340,7 +340,8 @@ class LDAIClient:
                 return None
 
             return Judge(judge_config, provider, sample_rate=sample_rate)
-        except Exception as error:
+        except Exception as e:
+            log.warning('Failed to initialize judge %r: %s', key, e)
             return None
 
     def _build_evaluator(

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -339,7 +339,7 @@ class LDAIClient:
             if not provider:
                 return None
 
-            return Judge(judge_config, provider, sample_rate=sample_rate)  # type: ignore[arg-type]
+            return Judge(judge_config, provider, sample_rate=sample_rate)
         except Exception as error:
             return None
 

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -339,9 +339,8 @@ class LDAIClient:
             if not provider:
                 return None
 
-            return Judge(judge_config, provider, sample_rate=sample_rate)
-        except Exception as e:
-            log.warning('Failed to initialize judge %r: %s', key, e)
+            return Judge(judge_config, provider, sample_rate=sample_rate)  # type: ignore[arg-type]
+        except Exception as error:
             return None
 
     def _build_evaluator(

--- a/packages/sdk/server-ai/tests/test_judge.py
+++ b/packages/sdk/server-ai/tests/test_judge.py
@@ -333,7 +333,7 @@ class TestJudgeEvaluate:
 
         assert isinstance(result, JudgeResult)
         assert result.sampled is False
-        mock_runner.invoke_structured_model.assert_not_called()
+        mock_runner.run.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_evaluate_arg_overrides_instance_sample_rate(
@@ -346,7 +346,7 @@ class TestJudgeEvaluate:
 
         assert isinstance(result, JudgeResult)
         assert result.sampled is False
-        mock_runner.invoke_structured_model.assert_not_called()
+        mock_runner.run.assert_not_called()
 
 
 class TestJudgeEvaluateMessages:


### PR DESCRIPTION
## Summary

- \`LangChainModelRunner\` and \`LangChainAgentRunner\` now formally inherit from the \`Runner\` protocol class.
- \`LangChainModelRunner.run()\` implements the unified \`Runner\` protocol; returns \`RunnerResult\` with \`content\`, \`metrics\`, \`raw\`, and \`parsed\` fields. Structured output is supported via the \`output_type\` parameter.
- \`LangChainAgentRunner.run()\` updated to return \`RunnerResult\`; populates \`tool_calls\` in \`LDAIMetrics\` from observed tool call names in the message response.
- Legacy \`invoke_model()\` and \`invoke_structured_model()\` removed — the deprecated type *definitions* (\`ModelRunner\`, \`AgentRunner\`, \`ModelResponse\`, etc.) are kept in \`server-ai\` for provider CI compatibility until a cleanup PR removes them.

## Stacking

Stacked on top of \`jb/aic-2388/openai-runner-protocol\` (PR #149).

## Test plan

- [ ] \`make test-langchain\` — all LangChain provider tests pass
- [ ] \`make test\` — all tests across server-ai, langchain, and openai packages pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is an API-shape change for LangChain runners (moving to `Runner.run()` + `RunnerResult` and removing old response types), which could break downstream integrations and metric parsing if any callers still expect the legacy methods/fields.
> 
> **Overview**
> Updates the LangChain integration to the unified `Runner` protocol: `LangChainModelRunner` and `LangChainAgentRunner` now expose a single `run(input, output_type=...)` that returns `RunnerResult` (`content`, `raw`, optional `parsed`) instead of the legacy `invoke_model`/`invoke_structured_model` responses.
> 
> Adds structured-output support to `LangChainModelRunner.run()` via `output_type` and normalizes inputs (string vs `List[LDMessage]`), and enhances agent runs to capture tool call names into `LDAIMetrics.tool_calls`.
> 
> Docs and tests are updated to use `LDAIClient.create_model`/`ManagedModel.run()` and the new result shapes; LangGraph agent-graph running no longer returns evaluation results on `AgentGraphResult` (they’re only flushed/tracked internally).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e61d4277d16dc25dfc8e2316a597c9daa72064a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->