### PR TITLE
feat: Update OpenAI graph runner to return AgentGraphRunnerResult with GraphMetrics

### DIFF
--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -120,6 +120,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                     success=False,
                     path=path,
                     duration_ms=duration_ms,
+                    node_metrics=self._node_metrics,
                 ),
             )
 

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -4,8 +4,8 @@ from typing import Any, Dict, List, Optional
 
 from ldai import log
 from ldai.agent_graph import AgentGraphDefinition, AgentGraphNode
-from ldai.providers import AgentGraphResult, AgentGraphRunner, ToolRegistry
-from ldai.providers.types import LDAIMetrics
+from ldai.providers import AgentGraphRunner, ToolRegistry
+from ldai.providers.types import AgentGraphRunnerResult, GraphMetrics, LDAIMetrics
 from ldai.tracker import TokenUsage
 
 from ldai_openai.openai_helper import (
@@ -20,6 +20,34 @@ from ldai_openai.openai_helper import (
 def _sanitize_agent_name(key: str) -> str:
     """Replace characters invalid for OpenAI function names with underscores."""
     return re.sub(r'[^a-zA-Z0-9_]', '_', key)
+
+
+class _NodeMetricsAccumulator:
+    """Mutable per-node metrics collected during a run (replaces LDAIConfigTracker)."""
+
+    def __init__(self) -> None:
+        self.usage: Optional[TokenUsage] = None
+        self.duration_ms: Optional[int] = None
+        self.tool_calls: List[str] = []
+        self.success: bool = True
+
+    def set_usage(self, usage: Optional[TokenUsage]) -> None:
+        if usage is not None:
+            self.usage = usage
+
+    def set_duration_ms(self, duration_ms: int) -> None:
+        self.duration_ms = duration_ms
+
+    def add_tool_call(self, tool_name: str) -> None:
+        self.tool_calls.append(tool_name)
+
+    def to_ldai_metrics(self) -> LDAIMetrics:
+        return LDAIMetrics(
+            success=self.success,
+            usage=self.usage,
+            duration_ms=self.duration_ms,
+            tool_calls=self.tool_calls if self.tool_calls else None,
+        )
 
 
 class _RunState:
@@ -39,9 +67,10 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
 
     AgentGraphRunner implementation for the OpenAI Agents SDK.
 
-    Runs the agent graph with the OpenAI Agents SDK and automatically records
-    graph- and node-level AI metric data to the LaunchDarkly trackers on the
-    graph definition and each node.
+    Runs the agent graph with the OpenAI Agents SDK and collects graph- and
+    node-level metrics.  Tracking events are emitted by the managed layer
+    (:class:`~ldai.ManagedAgentGraph`) from the returned
+    :class:`~ldai.providers.types.AgentGraphRunnerResult`.
 
     Requires ``openai-agents`` to be installed.
     """
@@ -61,20 +90,19 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         self._tools = tools
         self._agent_name_map: Dict[str, str] = {}
         self._tool_name_map: Dict[str, str] = {}
-        self._node_trackers: Dict[str, Any] = {}
+        self._node_accumulators: Dict[str, _NodeMetricsAccumulator] = {}
 
-    async def run(self, input: Any) -> AgentGraphResult:
+    async def run(self, input: Any) -> AgentGraphRunnerResult:
         """
         Run the agent graph with the given input.
 
         Builds the agent tree via reverse_traverse, then invokes the root
-        agent with Runner.run(). Tracks path, latency, and invocation
-        success/failure.
+        agent with Runner.run(). Collects path, latency, and per-node metrics.
+        Graph-level tracking events are emitted by the managed layer.
 
         :param input: The string prompt to send to the agent graph
-        :return: AgentGraphResult with the final output and metrics
+        :return: AgentGraphRunnerResult with the final content and GraphMetrics
         """
-        tracker = self._graph.create_tracker()
         path: List[str] = []
         root_node = self._graph.root()
         root_key = root_node.get_key() if root_node else ''
@@ -86,24 +114,29 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         state = _RunState(last_handoff_ns=start_ns, last_node_key=root_key)
         try:
             from agents import Runner
-            root_agent = self._build_agents(path, state, tracker)
+            root_agent = self._build_agents(path, state)
             result = await Runner.run(root_agent, input_str)
             self._flush_final_segment(state, result)
-            self._track_tool_calls(result)
+            self._collect_tool_calls(result)
 
-            duration = (time.perf_counter_ns() - start_ns) // 1_000_000
+            duration_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
             token_usage = get_ai_usage_from_response(result)
 
-            tracker.track_path(path)
-            tracker.track_duration(duration)
-            tracker.track_invocation_success()
-            if token_usage is not None:
-                tracker.track_total_tokens(token_usage)
+            node_metrics = {
+                key: acc.to_ldai_metrics()
+                for key, acc in self._node_accumulators.items()
+            }
 
-            return AgentGraphResult(
-                output=str(result.final_output),
+            return AgentGraphRunnerResult(
+                content=str(result.final_output),
                 raw=result,
-                metrics=LDAIMetrics(success=True, usage=token_usage),
+                metrics=GraphMetrics(
+                    success=True,
+                    path=path,
+                    duration_ms=duration_ms,
+                    usage=token_usage,
+                    node_metrics=node_metrics,
+                ),
             )
         except Exception as exc:
             if isinstance(exc, ImportError):
@@ -113,17 +146,19 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                 )
             else:
                 log.warning(f'OpenAIAgentGraphRunner run failed: {exc}')
-            duration = (time.perf_counter_ns() - start_ns) // 1_000_000
-            tracker.track_duration(duration)
-            tracker.track_invocation_failure()
-            return AgentGraphResult(
-                output='',
+            duration_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
+            return AgentGraphRunnerResult(
+                content='',
                 raw=None,
-                metrics=LDAIMetrics(success=False),
+                metrics=GraphMetrics(
+                    success=False,
+                    path=path,
+                    duration_ms=duration_ms,
+                ),
             )
 
     def _build_agents(
-        self, path: List[str], state: _RunState, tracker: Any
+        self, path: List[str], state: _RunState
     ) -> Any:
         """
         Build the agent tree from the graph definition via reverse_traverse.
@@ -133,7 +168,6 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
 
         :param path: Mutable list to accumulate the execution path
         :param state: Shared run state for tracking handoff timing and last node
-        :param tracker: Graph-level tracker shared across the entire run
         :return: The root Agent instance
         """
         try:
@@ -151,12 +185,12 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
 
         name_map: Dict[str, str] = {}
         tool_name_map: Dict[str, str] = {}
-        node_trackers: Dict[str, Any] = {}
+        node_accumulators: Dict[str, _NodeMetricsAccumulator] = {}
 
         def build_node(node: AgentGraphNode, ctx: dict) -> Any:
             node_config = node.get_config()
-            config_tracker = node_config.create_tracker()
-            node_trackers[node_config.key] = config_tracker
+            acc = _NodeMetricsAccumulator()
+            node_accumulators[node_config.key] = acc
             model = node_config.model
 
             if not model:
@@ -177,8 +211,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                             node_config.key,
                             target_key,
                             path,
-                            tracker,
-                            config_tracker,
+                            acc,
                             state,
                         ),
                     )
@@ -212,7 +245,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         root = self._graph.reverse_traverse(fn=build_node)
         self._agent_name_map = name_map
         self._tool_name_map = tool_name_map
-        self._node_trackers = node_trackers
+        self._node_accumulators = node_accumulators
         return root
 
     def _make_on_handoff(
@@ -220,12 +253,11 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         src: str,
         tgt: str,
         path: List[str],
-        tracker: Any,
-        config_tracker: Any,
+        acc: _NodeMetricsAccumulator,
         state: _RunState,
     ):
         def on_handoff(run_ctx: Any) -> None:
-            self._handle_handoff(run_ctx, src, tgt, path, tracker, config_tracker, state)
+            self._handle_handoff(run_ctx, src, tgt, path, acc, state)
         return on_handoff
 
     def _handle_handoff(
@@ -234,13 +266,11 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         src: str,
         tgt: str,
         path: List[str],
-        tracker: Any,
-        config_tracker: Any,
+        acc: _NodeMetricsAccumulator,
         state: _RunState,
     ) -> None:
         path.append(tgt)
         state.last_node_key = tgt
-        tracker.track_handoff_success(src, tgt)
 
         now_ns = time.perf_counter_ns()
         duration_ms = (now_ns - state.last_handoff_ns) // 1_000_000
@@ -254,19 +284,15 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         except Exception:
             pass
 
-        if config_tracker is not None:
-            if usage is not None:
-                config_tracker.track_tokens(usage)
-            if duration_ms is not None:
-                config_tracker.track_duration(int(duration_ms))
-            config_tracker.track_success()
+        acc.set_usage(usage)
+        acc.set_duration_ms(int(duration_ms))
 
     def _flush_final_segment(self, state: _RunState, result: Any) -> None:
         """Record duration/tokens for the last active agent (no handoff after it)."""
         if not state.last_node_key:
             return
-        config_tracker = self._node_trackers.get(state.last_node_key)
-        if config_tracker is None:
+        acc = self._node_accumulators.get(state.last_node_key)
+        if acc is None:
             return
 
         now_ns = time.perf_counter_ns()
@@ -280,18 +306,16 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         except Exception:
             pass
 
-        if usage is not None:
-            config_tracker.track_tokens(usage)
-        config_tracker.track_duration(int(duration_ms))
-        config_tracker.track_success()
+        acc.set_usage(usage)
+        acc.set_duration_ms(int(duration_ms))
 
-    def _track_tool_calls(self, result: Any) -> None:
-        """Track all tool calls from the run result, attributed to the node that called them."""
+    def _collect_tool_calls(self, result: Any) -> None:
+        """Collect all tool calls from the run result, attributed to the node that called them."""
         for agent_name, tool_fn_name in get_tool_calls_from_run_items(result.new_items):
             agent_key = self._agent_name_map.get(agent_name, agent_name)
             tool_name = self._tool_name_map.get(tool_fn_name)
             if tool_name is None:
                 continue
-            config_tracker = self._node_trackers.get(agent_key)
-            if config_tracker is not None:
-                config_tracker.track_tool_call(tool_name)
+            acc = self._node_accumulators.get(agent_key)
+            if acc is not None:
+                acc.add_tool_call(tool_name)

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -86,6 +86,8 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         try:
             from agents import Runner
             root_agent = self._build_agents(path, state)
+            if root_key:
+                self._node_metrics[root_key] = LDAIMetrics(success=False)
             result = await Runner.run(root_agent, input_str)
             self._flush_final_segment(state, result)
             self._collect_tool_calls(result)
@@ -152,12 +154,9 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
 
         name_map: Dict[str, str] = {}
         tool_name_map: Dict[str, str] = {}
-        node_metrics: Dict[str, LDAIMetrics] = {}
 
         def build_node(node: AgentGraphNode, ctx: dict) -> Any:
             node_config = node.get_config()
-            metrics = LDAIMetrics(success=True)
-            node_metrics[node_config.key] = metrics
             model = node_config.model
 
             if not model:
@@ -178,7 +177,6 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                             node_config.key,
                             target_key,
                             path,
-                            metrics,
                             state,
                         ),
                     )
@@ -212,7 +210,6 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         root = self._graph.reverse_traverse(fn=build_node)
         self._agent_name_map = name_map
         self._tool_name_map = tool_name_map
-        self._node_metrics = node_metrics
         return root
 
     def _make_on_handoff(
@@ -220,11 +217,10 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         src: str,
         tgt: str,
         path: List[str],
-        metrics: LDAIMetrics,
         state: _RunState,
     ):
         def on_handoff(run_ctx: Any) -> None:
-            self._handle_handoff(run_ctx, src, tgt, path, metrics, state)
+            self._handle_handoff(run_ctx, src, tgt, path, state)
         return on_handoff
 
     def _handle_handoff(
@@ -233,24 +229,27 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         src: str,
         tgt: str,
         path: List[str],
-        metrics: LDAIMetrics,
         state: _RunState,
     ) -> None:
         path.append(tgt)
-        state.last_node_key = tgt
 
         now_ns = time.perf_counter_ns()
         duration_ms = (now_ns - state.last_handoff_ns) // 1_000_000
         state.last_handoff_ns = now_ns
 
-        try:
-            metrics.usage = extract_usage_from_request_entry(
-                run_ctx.usage.request_usage_entries[-1]
-            )
-        except Exception:
-            pass
+        src_metrics = self._node_metrics.get(src)
+        if src_metrics is not None:
+            src_metrics.success = True
+            src_metrics.duration_ms = int(duration_ms)
+            try:
+                src_metrics.usage = extract_usage_from_request_entry(
+                    run_ctx.usage.request_usage_entries[-1]
+                )
+            except Exception:
+                pass
 
-        metrics.duration_ms = int(duration_ms)
+        self._node_metrics[tgt] = LDAIMetrics(success=False)
+        state.last_node_key = tgt
 
     def _flush_final_segment(self, state: _RunState, result: Any) -> None:
         """Record duration/tokens for the last active agent (no handoff after it)."""
@@ -260,6 +259,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         if metrics is None:
             return
 
+        metrics.success = True
         now_ns = time.perf_counter_ns()
         metrics.duration_ms = int((now_ns - state.last_handoff_ns) // 1_000_000)
 

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -1,12 +1,11 @@
 import re
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 from ldai import log
 from ldai.agent_graph import AgentGraphDefinition, AgentGraphNode
 from ldai.providers import AgentGraphRunner, ToolRegistry
 from ldai.providers.types import AgentGraphRunnerResult, GraphMetrics, LDAIMetrics
-from ldai.tracker import TokenUsage
 
 from ldai_openai.openai_helper import (
     extract_usage_from_request_entry,
@@ -20,34 +19,6 @@ from ldai_openai.openai_helper import (
 def _sanitize_agent_name(key: str) -> str:
     """Replace characters invalid for OpenAI function names with underscores."""
     return re.sub(r'[^a-zA-Z0-9_]', '_', key)
-
-
-class _NodeMetricsAccumulator:
-    """Mutable per-node metrics collected during a run (replaces LDAIConfigTracker)."""
-
-    def __init__(self) -> None:
-        self.usage: Optional[TokenUsage] = None
-        self.duration_ms: Optional[int] = None
-        self.tool_calls: List[str] = []
-        self.success: bool = True
-
-    def set_usage(self, usage: Optional[TokenUsage]) -> None:
-        if usage is not None:
-            self.usage = usage
-
-    def set_duration_ms(self, duration_ms: int) -> None:
-        self.duration_ms = duration_ms
-
-    def add_tool_call(self, tool_name: str) -> None:
-        self.tool_calls.append(tool_name)
-
-    def to_ldai_metrics(self) -> LDAIMetrics:
-        return LDAIMetrics(
-            success=self.success,
-            usage=self.usage,
-            duration_ms=self.duration_ms,
-            tool_calls=self.tool_calls if self.tool_calls else None,
-        )
 
 
 class _RunState:
@@ -90,7 +61,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         self._tools = tools
         self._agent_name_map: Dict[str, str] = {}
         self._tool_name_map: Dict[str, str] = {}
-        self._node_accumulators: Dict[str, _NodeMetricsAccumulator] = {}
+        self._node_metrics: Dict[str, LDAIMetrics] = {}
 
     async def run(self, input: Any) -> AgentGraphRunnerResult:
         """
@@ -122,11 +93,6 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
             duration_ms = (time.perf_counter_ns() - start_ns) // 1_000_000
             token_usage = get_ai_usage_from_response(result)
 
-            node_metrics = {
-                key: acc.to_ldai_metrics()
-                for key, acc in self._node_accumulators.items()
-            }
-
             return AgentGraphRunnerResult(
                 content=str(result.final_output),
                 raw=result,
@@ -135,7 +101,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                     path=path,
                     duration_ms=duration_ms,
                     usage=token_usage,
-                    node_metrics=node_metrics,
+                    node_metrics=self._node_metrics,
                 ),
             )
         except Exception as exc:
@@ -185,12 +151,12 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
 
         name_map: Dict[str, str] = {}
         tool_name_map: Dict[str, str] = {}
-        node_accumulators: Dict[str, _NodeMetricsAccumulator] = {}
+        node_metrics: Dict[str, LDAIMetrics] = {}
 
         def build_node(node: AgentGraphNode, ctx: dict) -> Any:
             node_config = node.get_config()
-            acc = _NodeMetricsAccumulator()
-            node_accumulators[node_config.key] = acc
+            metrics = LDAIMetrics(success=True)
+            node_metrics[node_config.key] = metrics
             model = node_config.model
 
             if not model:
@@ -211,7 +177,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                             node_config.key,
                             target_key,
                             path,
-                            acc,
+                            metrics,
                             state,
                         ),
                     )
@@ -245,7 +211,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         root = self._graph.reverse_traverse(fn=build_node)
         self._agent_name_map = name_map
         self._tool_name_map = tool_name_map
-        self._node_accumulators = node_accumulators
+        self._node_metrics = node_metrics
         return root
 
     def _make_on_handoff(
@@ -253,11 +219,11 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         src: str,
         tgt: str,
         path: List[str],
-        acc: _NodeMetricsAccumulator,
+        metrics: LDAIMetrics,
         state: _RunState,
     ):
         def on_handoff(run_ctx: Any) -> None:
-            self._handle_handoff(run_ctx, src, tgt, path, acc, state)
+            self._handle_handoff(run_ctx, src, tgt, path, metrics, state)
         return on_handoff
 
     def _handle_handoff(
@@ -266,7 +232,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         src: str,
         tgt: str,
         path: List[str],
-        acc: _NodeMetricsAccumulator,
+        metrics: LDAIMetrics,
         state: _RunState,
     ) -> None:
         path.append(tgt)
@@ -276,38 +242,32 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         duration_ms = (now_ns - state.last_handoff_ns) // 1_000_000
         state.last_handoff_ns = now_ns
 
-        usage: Optional[TokenUsage] = None
         try:
-            usage = extract_usage_from_request_entry(
+            metrics.usage = extract_usage_from_request_entry(
                 run_ctx.usage.request_usage_entries[-1]
             )
         except Exception:
             pass
 
-        acc.set_usage(usage)
-        acc.set_duration_ms(int(duration_ms))
+        metrics.duration_ms = int(duration_ms)
 
     def _flush_final_segment(self, state: _RunState, result: Any) -> None:
         """Record duration/tokens for the last active agent (no handoff after it)."""
         if not state.last_node_key:
             return
-        acc = self._node_accumulators.get(state.last_node_key)
-        if acc is None:
+        metrics = self._node_metrics.get(state.last_node_key)
+        if metrics is None:
             return
 
         now_ns = time.perf_counter_ns()
-        duration_ms = (now_ns - state.last_handoff_ns) // 1_000_000
+        metrics.duration_ms = int((now_ns - state.last_handoff_ns) // 1_000_000)
 
-        usage: Optional[TokenUsage] = None
         try:
-            usage = extract_usage_from_request_entry(
+            metrics.usage = extract_usage_from_request_entry(
                 result.context_wrapper.usage.request_usage_entries[-1]
             )
         except Exception:
             pass
-
-        acc.set_usage(usage)
-        acc.set_duration_ms(int(duration_ms))
 
     def _collect_tool_calls(self, result: Any) -> None:
         """Collect all tool calls from the run result, attributed to the node that called them."""
@@ -316,6 +276,9 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
             tool_name = self._tool_name_map.get(tool_fn_name)
             if tool_name is None:
                 continue
-            acc = self._node_accumulators.get(agent_key)
-            if acc is not None:
-                acc.add_tool_call(tool_name)
+            metrics = self._node_metrics.get(agent_key)
+            if metrics is not None:
+                if metrics.tool_calls is None:
+                    metrics.tool_calls = [tool_name]
+                else:
+                    metrics.tool_calls.append(tool_name)

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -74,6 +74,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         :param input: The string prompt to send to the agent graph
         :return: AgentGraphRunnerResult with the final content and GraphMetrics
         """
+        self._node_metrics = {}
         path: List[str] = []
         root_node = self._graph.root()
         root_key = root_node.get_key() if root_node else ''

--- a/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
@@ -94,8 +94,38 @@ async def test_openai_agent_graph_runner_run_failure_returns_metrics():
     assert isinstance(result, AgentGraphRunnerResult)
     assert result.metrics.success is False
     assert result.metrics.duration_ms is not None
+    # Import failure happens before node metrics are created
+    assert len(result.metrics.node_metrics) == 0
     # Runner no longer calls graph tracker — graph.create_tracker should NOT be called
     graph.create_tracker.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_openai_agent_graph_runner_run_failure_marks_node_not_success():
+    """When Runner.run() raises, started nodes retain success=False."""
+    graph = _make_graph()
+
+    mock_agents = MagicMock()
+    mock_agents.Runner.run = AsyncMock(side_effect=RuntimeError("boom"))
+    mock_agents.Agent = MagicMock(return_value=MagicMock())
+    mock_agents.Handoff = MagicMock()
+    mock_agents.handoff = MagicMock()
+
+    mock_agents_ext = MagicMock()
+    mock_agents_ext.RECOMMENDED_PROMPT_PREFIX = '[PREFIX]'
+
+    with patch.dict('sys.modules', {
+        'agents': mock_agents,
+        'agents.extensions': MagicMock(),
+        'agents.extensions.handoff_prompt': mock_agents_ext,
+        'agents.tool_context': MagicMock(),
+    }):
+        runner = OpenAIAgentGraphRunner(graph, {})
+        result = await runner.run("test input")
+
+    assert result.metrics.success is False
+    assert 'root-agent' in result.metrics.node_metrics
+    assert result.metrics.node_metrics['root-agent'].success is False
 
 
 @pytest.mark.asyncio
@@ -153,3 +183,4 @@ async def test_openai_agent_graph_runner_run_success():
 
     # Runner accumulates per-node metrics in _node_metrics
     assert 'root-agent' in runner._node_metrics
+    assert runner._node_metrics['root-agent'].success is True

--- a/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
@@ -5,7 +5,8 @@ from unittest.mock import MagicMock, AsyncMock, patch
 
 from ldai.agent_graph import AgentGraphDefinition
 from ldai.models import AIAgentGraphConfig, AIAgentConfig, Edge, ModelConfig, ProviderConfig
-from ldai.providers import AgentGraphResult, ToolRegistry
+from ldai.providers import ToolRegistry
+from ldai.providers.types import AgentGraphRunnerResult, GraphMetrics
 from ldai_openai.openai_agent_graph_runner import OpenAIAgentGraphRunner
 from ldai_openai.openai_runner_factory import OpenAIRunnerFactory
 from ldai.evaluator import Evaluator
@@ -13,10 +14,8 @@ from ldai.evaluator import Evaluator
 
 def _make_graph(enabled: bool = True) -> AgentGraphDefinition:
     """Build a minimal single-node AgentGraphDefinition for testing."""
-    node_tracker = MagicMock()
-    graph_tracker = MagicMock()
-    node_factory = MagicMock(return_value=node_tracker)
-    graph_factory = MagicMock(return_value=graph_tracker)
+    node_factory = MagicMock()
+    graph_factory = MagicMock()
     root_config = AIAgentConfig(
         key='root-agent',
         enabled=enabled,
@@ -73,41 +72,44 @@ def test_openai_agent_graph_runner_stores_graph_and_tools():
 
 @pytest.mark.asyncio
 async def test_openai_agent_graph_runner_run_raises_when_agents_not_installed():
+    """Import failure returns AgentGraphRunnerResult with success=False."""
     graph = _make_graph()
     runner = OpenAIAgentGraphRunner(graph, {})
 
     with patch.dict('sys.modules', {'agents': None}):
-        # The import inside run() will fail — runner should return failure result
-        # rather than propagate the ImportError, since it's caught by the except block
         result = await runner.run("test input")
-        assert isinstance(result, AgentGraphResult)
+        assert isinstance(result, AgentGraphRunnerResult)
         assert result.metrics.success is False
 
 
 @pytest.mark.asyncio
-async def test_openai_agent_graph_runner_run_tracks_invocation_failure_on_exception():
+async def test_openai_agent_graph_runner_run_failure_returns_metrics():
+    """On import failure, returned GraphMetrics has success=False (no tracker needed)."""
     graph = _make_graph()
-    tracker = graph.create_tracker.return_value
     runner = OpenAIAgentGraphRunner(graph, {})
 
     with patch.dict('sys.modules', {'agents': None}):
         result = await runner.run("fail")
 
+    assert isinstance(result, AgentGraphRunnerResult)
     assert result.metrics.success is False
-    tracker.track_invocation_failure.assert_called_once()
-    tracker.track_duration.assert_called_once()
+    assert result.metrics.duration_ms is not None
+    # Runner no longer calls graph tracker — graph.create_tracker should NOT be called
+    graph.create_tracker.assert_not_called()
 
 
 @pytest.mark.asyncio
 async def test_openai_agent_graph_runner_run_success():
+    """Successful run returns AgentGraphRunnerResult with populated GraphMetrics."""
     graph = _make_graph()
-    tracker = graph.create_tracker.return_value
 
     mock_result = MagicMock()
     mock_result.final_output = "agent answer"
-    mock_result.context_wrapper.usage.total_tokens = 0
-    mock_result.context_wrapper.usage.input_tokens = 0
-    mock_result.context_wrapper.usage.output_tokens = 0
+    mock_result.new_items = []
+    mock_result.context_wrapper.usage.total_tokens = 10
+    mock_result.context_wrapper.usage.input_tokens = 5
+    mock_result.context_wrapper.usage.output_tokens = 5
+    mock_result.context_wrapper.usage.request_usage_entries = []
 
     mock_runner_module = MagicMock()
     mock_runner_module.run = AsyncMock(return_value=mock_result)
@@ -135,28 +137,19 @@ async def test_openai_agent_graph_runner_run_success():
         runner = OpenAIAgentGraphRunner(graph, {})
         result = await runner.run("find restaurants")
 
-    assert isinstance(result, AgentGraphResult)
-    assert result.output == "agent answer"
+    assert isinstance(result, AgentGraphRunnerResult)
+    assert result.content == "agent answer"
+    assert isinstance(result.metrics, GraphMetrics)
     assert result.metrics.success is True
-    tracker.track_invocation_success.assert_called_once()
-    tracker.track_path.assert_called_once()
-    tracker.track_duration.assert_called_once()
+    assert result.metrics.duration_ms is not None
+    assert 'root-agent' in result.metrics.path
 
-    # The runner caches one tracker per node — verify it is the same instance
-    # returned by create_tracker() and that all tracking calls hit it.
+    # Runner no longer creates or calls the graph tracker
+    graph.create_tracker.assert_not_called()
+
+    # Runner no longer creates per-node LDAIConfigTracker instances
     node_factory = graph.get_node('root-agent').get_config().create_tracker
+    node_factory.assert_not_called()
 
-    # The runner caches one tracker per node — verify it is the same instance
-    # returned by create_tracker and that all tracking calls hit it.
-    cached = runner._node_trackers['root-agent']
-    assert cached is node_factory.return_value
-    cached.track_duration.assert_called_once()
-    cached.track_tokens.assert_called_once()
-    cached.track_success.assert_called_once()
-
-    # Graph-level create_tracker is called exactly once per run (not twice)
-    # so that handoff callbacks and run() share the same tracker instance.
-    graph.create_tracker.assert_called_once()
-
-    # Node-level create_tracker is called exactly once per node.
-    node_factory.assert_called_once()
+    # Runner accumulates per-node metrics in _node_accumulators
+    assert 'root-agent' in runner._node_accumulators

--- a/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
@@ -151,5 +151,5 @@ async def test_openai_agent_graph_runner_run_success():
     node_factory = graph.get_node('root-agent').get_config().create_tracker
     node_factory.assert_not_called()
 
-    # Runner accumulates per-node metrics in _node_accumulators
-    assert 'root-agent' in runner._node_accumulators
+    # Runner accumulates per-node metrics in _node_metrics
+    assert 'root-agent' in runner._node_metrics

--- a/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_openai_agent_graph_runner.py
@@ -184,3 +184,43 @@ async def test_openai_agent_graph_runner_run_success():
     # Runner accumulates per-node metrics in _node_metrics
     assert 'root-agent' in runner._node_metrics
     assert runner._node_metrics['root-agent'].success is True
+
+
+@pytest.mark.asyncio
+async def test_openai_agent_graph_runner_run_resets_node_metrics_between_runs():
+    """Successive runs do not leak stale node metrics from a previous run."""
+    graph = _make_graph()
+
+    mock_result = MagicMock()
+    mock_result.final_output = "answer"
+    mock_result.new_items = []
+    mock_result.context_wrapper.usage.request_usage_entries = []
+
+    mock_agents = MagicMock()
+    mock_agents.Runner.run = AsyncMock(
+        side_effect=[RuntimeError("boom"), mock_result]
+    )
+    mock_agents.Agent = MagicMock(return_value=MagicMock())
+    mock_agents.Handoff = MagicMock()
+    mock_agents.handoff = MagicMock()
+
+    mock_agents_ext = MagicMock()
+    mock_agents_ext.RECOMMENDED_PROMPT_PREFIX = '[PREFIX]'
+
+    with patch.dict('sys.modules', {
+        'agents': mock_agents,
+        'agents.extensions': MagicMock(),
+        'agents.extensions.handoff_prompt': mock_agents_ext,
+        'agents.tool_context': MagicMock(),
+    }):
+        runner = OpenAIAgentGraphRunner(graph, {})
+
+        first = await runner.run("attempt 1")
+        assert first.metrics.success is False
+        assert first.metrics.node_metrics['root-agent'].success is False
+        failed_metrics = first.metrics.node_metrics['root-agent']
+
+        second = await runner.run("attempt 2")
+        assert second.metrics.success is True
+        assert second.metrics.node_metrics['root-agent'].success is True
+        assert second.metrics.node_metrics['root-agent'] is not failed_metrics

--- a/packages/ai-providers/server-ai-openai/tests/test_tracking_openai_agents.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_tracking_openai_agents.py
@@ -1,9 +1,13 @@
 """
-Integration tests for OpenAIAgentGraphRunner tracking pipeline.
+Integration tests for OpenAIAgentGraphRunner + ManagedAgentGraph tracking pipeline.
 
 Uses real AIGraphTracker and LDAIConfigTracker backed by a mock LD client,
 and a crafted RunResult to verify that the correct LD events are emitted
 with the correct payloads — without making real API calls.
+
+Tracking events are now emitted by ManagedAgentGraph._flush_graph_tracking()
+from the GraphMetrics returned by the runner, rather than directly inside the
+runner. These tests exercise the full pipeline through ManagedAgentGraph.run().
 """
 
 import pytest
@@ -11,6 +15,7 @@ from collections import defaultdict
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from ldai.agent_graph import AgentGraphDefinition
+from ldai.managed_agent_graph import ManagedAgentGraph
 from ldai.models import AIAgentGraphConfig, AIAgentConfig, Edge, ModelConfig, ProviderConfig
 from ldai.tracker import AIGraphTracker, LDAIConfigTracker
 from ldai_openai.openai_agent_graph_runner import OpenAIAgentGraphRunner
@@ -253,6 +258,12 @@ def _events(mock_ld_client: MagicMock) -> dict:
     return dict(result)
 
 
+async def _run_through_managed(graph: AgentGraphDefinition, runner: OpenAIAgentGraphRunner, input: str):
+    """Run through the full ManagedAgentGraph pipeline so tracking events are emitted."""
+    managed = ManagedAgentGraph(graph, runner)
+    return await managed.run(input)
+
+
 # ---------------------------------------------------------------------------
 # Tests
 # ---------------------------------------------------------------------------
@@ -266,10 +277,10 @@ async def test_tracks_graph_invocation_success_and_latency():
 
     with patch.dict('sys.modules', _make_agents_modules(run_result)):
         runner = OpenAIAgentGraphRunner(graph, {})
-        result = await runner.run('hello')
+        result = await _run_through_managed(graph, runner, 'hello')
 
     assert result.metrics.success is True
-    assert result.output == 'done'
+    assert result.content == 'done'
 
     ev = _events(mock_ld_client)
     assert ev['$ld:ai:graph:invocation_success'][0][1] == 1
@@ -279,7 +290,7 @@ async def test_tracks_graph_invocation_success_and_latency():
 
 @pytest.mark.asyncio
 async def test_tracks_per_node_tokens_and_success():
-    """Node-level token and success events fire with correct values."""
+    """Node-level token and success events fire with correct values via managed layer."""
     mock_ld_client = MagicMock()
     graph = _make_graph(mock_ld_client, node_key='root-agent', graph_key='test-graph')
     run_result = _make_run_result(
@@ -291,11 +302,11 @@ async def test_tracks_per_node_tokens_and_success():
 
     with patch.dict('sys.modules', _make_agents_modules(run_result)):
         runner = OpenAIAgentGraphRunner(graph, {})
-        await runner.run('hello')
+        await _run_through_managed(graph, runner, 'hello')
 
     ev = _events(mock_ld_client)
 
-    # Node-level events
+    # Node-level events (emitted by ManagedAgentGraph from node_metrics)
     assert ev['$ld:ai:tokens:total'][0][1] == 30
     assert ev['$ld:ai:tokens:input'][0][1] == 20
     assert ev['$ld:ai:tokens:output'][0][1] == 10
@@ -314,7 +325,7 @@ async def test_tracks_graph_key_on_node_events():
 
     with patch.dict('sys.modules', _make_agents_modules(run_result)):
         runner = OpenAIAgentGraphRunner(graph, {})
-        await runner.run('hello')
+        await _run_through_managed(graph, runner, 'hello')
 
     ev = _events(mock_ld_client)
     token_data = ev['$ld:ai:tokens:total'][0][0]
@@ -332,7 +343,7 @@ async def test_tracks_tool_calls_from_run_items():
 
     with patch.dict('sys.modules', _make_agents_modules(run_result)):
         runner = OpenAIAgentGraphRunner(graph, _tool_registry('get_weather'))
-        await runner.run('What is the weather?')
+        await _run_through_managed(graph, runner, 'What is the weather?')
 
     ev = _events(mock_ld_client)
     tool_events = ev.get('$ld:ai:tool_call', [])
@@ -356,7 +367,7 @@ async def test_tracks_multiple_tool_calls():
 
     with patch.dict('sys.modules', _make_agents_modules(run_result)):
         runner = OpenAIAgentGraphRunner(graph, _tool_registry('search', 'summarize'))
-        await runner.run('Search and summarize.')
+        await _run_through_managed(graph, runner, 'Search and summarize.')
 
     ev = _events(mock_ld_client)
     tool_keys = [data['toolKey'] for data, _ in ev.get('$ld:ai:tool_call', [])]
@@ -379,7 +390,7 @@ async def test_same_run_id_across_token_success_and_tool_call_events():
 
     with patch.dict('sys.modules', _make_agents_modules(run_result)):
         runner = OpenAIAgentGraphRunner(graph, _tool_registry('search'))
-        await runner.run('go')
+        await _run_through_managed(graph, runner, 'go')
 
     ev = _events(mock_ld_client)
 
@@ -408,7 +419,7 @@ async def test_does_not_track_tool_calls_without_graph_and_registry_config():
 
     with patch.dict('sys.modules', _make_agents_modules(run_result)):
         runner = OpenAIAgentGraphRunner(graph, {})
-        await runner.run('prompt')
+        await _run_through_managed(graph, runner, 'prompt')
 
     ev = _events(mock_ld_client)
     assert ev.get('$ld:ai:tool_call', []) == []
@@ -420,10 +431,10 @@ async def test_tracks_failure_and_latency_on_runner_error():
     mock_ld_client = MagicMock()
     graph = _make_graph(mock_ld_client)
 
-    mock_runner = MagicMock()
-    mock_runner.run = AsyncMock(side_effect=RuntimeError('runner error'))
+    mock_runner_module = MagicMock()
+    mock_runner_module.run = AsyncMock(side_effect=RuntimeError('runner error'))
     mock_agents = MagicMock()
-    mock_agents.Runner = mock_runner
+    mock_agents.Runner = mock_runner_module
     mock_agents.Agent = MagicMock(return_value=MagicMock())
     mock_agents.Handoff = MagicMock()
     mock_agents.Tool = MagicMock()
@@ -439,7 +450,7 @@ async def test_tracks_failure_and_latency_on_runner_error():
         'agents.tool_context': MagicMock(),
     }):
         runner = OpenAIAgentGraphRunner(graph, {})
-        result = await runner.run('fail')
+        result = await _run_through_managed(graph, runner, 'fail')
 
     assert result.metrics.success is False
 
@@ -450,8 +461,8 @@ async def test_tracks_failure_and_latency_on_runner_error():
 
 
 @pytest.mark.asyncio
-async def test_multi_node_tracks_per_node_tokens_and_handoff():
-    """Each node emits its own token events; handoff event fires between them."""
+async def test_multi_node_tracks_per_node_tokens():
+    """Each node emits its own token events via the managed layer."""
     mock_ld_client = MagicMock()
     graph = _make_two_node_graph(mock_ld_client)
 
@@ -511,7 +522,7 @@ async def test_multi_node_tracks_per_node_tokens_and_handoff():
         'agents.tool_context': MagicMock(),
     }):
         runner = OpenAIAgentGraphRunner(graph, {})
-        result = await runner.run('hello')
+        result = await _run_through_managed(graph, runner, 'hello')
 
     assert result.metrics.success is True
 
@@ -527,9 +538,3 @@ async def test_multi_node_tracks_per_node_tokens_and_handoff():
     path_data = ev['$ld:ai:graph:path'][0][0]
     assert 'root-agent' in path_data['path']
     assert 'child-agent' in path_data['path']
-
-    # Handoff event fires with correct source and target
-    handoff_events = ev.get('$ld:ai:graph:handoff_success', [])
-    assert len(handoff_events) == 1
-    assert handoff_events[0][0]['sourceKey'] == 'root-agent'
-    assert handoff_events[0][0]['targetKey'] == 'child-agent'


### PR DESCRIPTION
## Summary

- Removes all direct LaunchDarkly tracker calls from `OpenAIAgentGraphRunner`
- Introduces `_NodeMetricsAccumulator` — a lightweight per-node metrics collector replacing `LDAIConfigTracker` inside the runner
- Runner now returns `AgentGraphRunnerResult` with populated `GraphMetrics` (`path`, `duration_ms`, `usage`, `node_metrics`)
- Graph-level and per-node tracking events are emitted by `ManagedAgentGraph._flush_graph_tracking()` from the result metrics
- `ManagedAgentGraph._flush_graph_tracking()` extended to drive per-node tracking from `result.metrics.node_metrics` using graph node tracker factories
- Integration tests updated to exercise the full `ManagedAgentGraph.run()` pipeline (tracking events now come from the managed layer)
- Handoff-level `track_handoff_success()` calls removed (per spec: `path` field is sufficient; handoffs are not in `GraphMetrics`)

## Depends on

- #154 (PR 11 — graph tracking refactor, bridge pattern for old/new runner shapes)

## Test plan

- [ ] All existing tests pass (`uv run pytest packages/ai-providers/server-ai-openai/tests/`)
- [ ] `test_openai_agent_graph_runner.py`: runner returns new shape, no tracker created
- [ ] `test_tracking_openai_agents.py`: graph-level and per-node events emitted through managed layer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runner result shape and shifts LaunchDarkly event emission from the OpenAI runner to `ManagedAgentGraph`, which could affect downstream integrations and metric correctness if node/path/usage attribution is wrong.
> 
> **Overview**
> `OpenAIAgentGraphRunner` now returns `AgentGraphRunnerResult` with `GraphMetrics` (`path`, `duration_ms`, `usage`, and per-node `node_metrics`) and **removes all direct LaunchDarkly tracker calls**, including handoff tracking.
> 
> Per-node durations/usage/tool calls are accumulated inside the runner (`_node_metrics`) during handoffs and final segment flush, and the integration path is updated so **`ManagedAgentGraph` emits graph + node tracking events** by consuming `result.metrics.node_metrics` and creating node trackers on demand.
> 
> Tests are updated to assert the new result fields, ensure trackers are no longer created/called by the runner, and to run tracking assertions through `ManagedAgentGraph.run()` (including failure cases and multi-node runs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa936cf5e8135fc879e2e4ae67bc1ce9c5a2a1d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->