### PR TITLE
fix: silently ignore model.parameters.tools when not a dict

### DIFF
--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -86,8 +86,6 @@ def _resolve_tools(variation: Dict[str, Any]) -> Optional[Dict[str, LDTool]]:
         return None
     tools_data = parameters.get('tools')
     if not isinstance(tools_data, dict):
-        if tools_data is not None:
-            log.warning('Skipping model.parameters.tools: expected a dict, got %s', type(tools_data).__name__)
         return None
 
     return _parse_tools(tools_data)


### PR DESCRIPTION
## Summary

- Removes spurious warning when `model.parameters.tools` is present but not a dict (e.g. a user-defined array of OpenAI-style tool objects)
- This case is intentionally silent — the user may have defined their own custom tool parameter and it is not our format

## Background

Follow-up to #146. A warning was added for `model.parameters.tools` being a non-dict type, but the original intent was that this case should be silently ignored since users legitimately pass custom tool arrays in model parameters.

Jira: AIC-1935

🤖 Generated with [Claude Code](https://claude.com/claude-code)