### PR TITLE
fix: reference correct PyPI package names in provider load error messages

### DIFF
--- a/packages/sdk/server-ai/src/ldai/providers/runner_factory.py
+++ b/packages/sdk/server-ai/src/ldai/providers/runner_factory.py
@@ -192,4 +192,4 @@ class RunnerFactory:
         """
         if util.find_spec(package_name) is None:
             pypi_name = _PYPI_PACKAGE_NAMES.get(package_name, package_name)
-            raise ImportError(f"Package '{pypi_name}' not found. Run: pip install {pypi_name}")
+            raise ImportError(f"Package '{pypi_name}' not found. Make sure it is installed.")

--- a/packages/sdk/server-ai/src/ldai/providers/runner_factory.py
+++ b/packages/sdk/server-ai/src/ldai/providers/runner_factory.py
@@ -13,6 +13,12 @@ T = TypeVar('T')
 # Multi-provider packages should be last in the list.
 SUPPORTED_AI_PROVIDERS = ('openai', 'langchain')
 
+# Mapping from internal Python module name to the pip-installable PyPI package name.
+_PYPI_PACKAGE_NAMES = {
+    'ldai_openai': 'launchdarkly-server-sdk-ai-openai',
+    'ldai_langchain': 'launchdarkly-server-sdk-ai-langchain',
+}
+
 
 class RunnerFactory:
     """
@@ -51,10 +57,7 @@ class RunnerFactory:
             )
             return None
         except ImportError as error:
-            log.warning(
-                f"Could not load provider '{provider_type}': {error}. "
-                f"Make sure the corresponding package is installed."
-            )
+            log.warning(f"Could not load provider '{provider_type}': {error}")
             return None
 
     @staticmethod
@@ -188,4 +191,5 @@ class RunnerFactory:
         :param package_name: Name of the package to check
         """
         if util.find_spec(package_name) is None:
-            raise ImportError(f"Package '{package_name}' not found")
+            pypi_name = _PYPI_PACKAGE_NAMES.get(package_name, package_name)
+            raise ImportError(f"Package '{pypi_name}' not found. Run: pip install {pypi_name}")

--- a/packages/sdk/server-ai/tests/test_runner_factory.py
+++ b/packages/sdk/server-ai/tests/test_runner_factory.py
@@ -16,7 +16,7 @@ class TestPkgExists:
             with pytest.raises(ImportError) as exc_info:
                 RunnerFactory._pkg_exists('ldai_openai')
         assert 'launchdarkly-server-sdk-ai-openai' in str(exc_info.value)
-        assert 'pip install launchdarkly-server-sdk-ai-openai' in str(exc_info.value)
+        assert 'pip install' not in str(exc_info.value)
 
     def test_raises_import_error_with_pypi_name_for_langchain(self):
         with patch('ldai.providers.runner_factory.util') as mock_util:
@@ -24,7 +24,7 @@ class TestPkgExists:
             with pytest.raises(ImportError) as exc_info:
                 RunnerFactory._pkg_exists('ldai_langchain')
         assert 'launchdarkly-server-sdk-ai-langchain' in str(exc_info.value)
-        assert 'pip install launchdarkly-server-sdk-ai-langchain' in str(exc_info.value)
+        assert 'pip install' not in str(exc_info.value)
 
     def test_raises_import_error_with_module_name_when_no_mapping(self):
         """Unknown module names fall back to the module name itself."""
@@ -74,11 +74,11 @@ class TestGetProviderFactory:
         assert 'launchdarkly-server-sdk-ai-langchain' in warning_text
         assert 'ldai_langchain' not in warning_text
 
-    def test_warning_does_not_contain_make_sure_text(self):
-        """The old boilerplate text should be replaced by actionable pip install instructions."""
+    def test_warning_does_not_reference_pip(self):
+        """Warning should be package-manager agnostic — no pip install command."""
         with patch('ldai.providers.runner_factory.util') as mock_util, \
              patch('ldai.providers.runner_factory.log') as mock_log:
             mock_util.find_spec.return_value = None
             RunnerFactory._get_provider_factory('openai')
         warning_text = mock_log.warning.call_args[0][0]
-        assert 'Make sure the corresponding package is installed' not in warning_text
+        assert 'pip install' not in warning_text

--- a/packages/sdk/server-ai/tests/test_runner_factory.py
+++ b/packages/sdk/server-ai/tests/test_runner_factory.py
@@ -1,0 +1,84 @@
+"""Tests for RunnerFactory provider loading and error messages."""
+
+from unittest.mock import patch
+
+import pytest
+
+from ldai.providers.runner_factory import RunnerFactory, _PYPI_PACKAGE_NAMES
+
+
+class TestPkgExists:
+    """_pkg_exists raises ImportError with the PyPI package name when a module is missing."""
+
+    def test_raises_import_error_with_pypi_name_for_openai(self):
+        with patch('ldai.providers.runner_factory.util') as mock_util:
+            mock_util.find_spec.return_value = None
+            with pytest.raises(ImportError) as exc_info:
+                RunnerFactory._pkg_exists('ldai_openai')
+        assert 'launchdarkly-server-sdk-ai-openai' in str(exc_info.value)
+        assert 'pip install launchdarkly-server-sdk-ai-openai' in str(exc_info.value)
+
+    def test_raises_import_error_with_pypi_name_for_langchain(self):
+        with patch('ldai.providers.runner_factory.util') as mock_util:
+            mock_util.find_spec.return_value = None
+            with pytest.raises(ImportError) as exc_info:
+                RunnerFactory._pkg_exists('ldai_langchain')
+        assert 'launchdarkly-server-sdk-ai-langchain' in str(exc_info.value)
+        assert 'pip install launchdarkly-server-sdk-ai-langchain' in str(exc_info.value)
+
+    def test_raises_import_error_with_module_name_when_no_mapping(self):
+        """Unknown module names fall back to the module name itself."""
+        with patch('ldai.providers.runner_factory.util') as mock_util:
+            mock_util.find_spec.return_value = None
+            with pytest.raises(ImportError) as exc_info:
+                RunnerFactory._pkg_exists('some_unknown_module')
+        assert 'some_unknown_module' in str(exc_info.value)
+
+    def test_does_not_raise_when_package_is_found(self):
+        with patch('ldai.providers.runner_factory.util') as mock_util:
+            mock_util.find_spec.return_value = object()  # non-None means found
+            # Should not raise
+            RunnerFactory._pkg_exists('ldai_openai')
+
+
+class TestPypiPackageNameMapping:
+    """The _PYPI_PACKAGE_NAMES mapping covers all supported providers."""
+
+    def test_openai_module_maps_to_pypi_name(self):
+        assert _PYPI_PACKAGE_NAMES['ldai_openai'] == 'launchdarkly-server-sdk-ai-openai'
+
+    def test_langchain_module_maps_to_pypi_name(self):
+        assert _PYPI_PACKAGE_NAMES['ldai_langchain'] == 'launchdarkly-server-sdk-ai-langchain'
+
+
+class TestGetProviderFactory:
+    """_get_provider_factory logs the PyPI package name in its warning when a package is missing."""
+
+    def test_warning_includes_pypi_name_for_openai(self):
+        with patch('ldai.providers.runner_factory.util') as mock_util, \
+             patch('ldai.providers.runner_factory.log') as mock_log:
+            mock_util.find_spec.return_value = None
+            result = RunnerFactory._get_provider_factory('openai')
+        assert result is None
+        warning_text = mock_log.warning.call_args[0][0]
+        assert 'launchdarkly-server-sdk-ai-openai' in warning_text
+        assert 'ldai_openai' not in warning_text
+
+    def test_warning_includes_pypi_name_for_langchain(self):
+        with patch('ldai.providers.runner_factory.util') as mock_util, \
+             patch('ldai.providers.runner_factory.log') as mock_log:
+            mock_util.find_spec.return_value = None
+            result = RunnerFactory._get_provider_factory('langchain')
+        assert result is None
+        warning_text = mock_log.warning.call_args[0][0]
+        assert 'launchdarkly-server-sdk-ai-langchain' in warning_text
+        assert 'ldai_langchain' not in warning_text
+
+    def test_warning_does_not_contain_make_sure_text(self):
+        """The old boilerplate text should be replaced by actionable pip install instructions."""
+        with patch('ldai.providers.runner_factory.util') as mock_util, \
+             patch('ldai.providers.runner_factory.log') as mock_log:
+            mock_util.find_spec.return_value = None
+            RunnerFactory._get_provider_factory('openai')
+        warning_text = mock_log.warning.call_args[0][0]
+        assert 'Make sure the corresponding package is installed' not in warning_text


### PR DESCRIPTION
## Summary

- The provider load error message previously referenced internal Python module names (`ldai_openai`, `ldai_langchain`) rather than the pip-installable PyPI package names, making the error unhelpful to end users.
- Added a `_PYPI_PACKAGE_NAMES` mapping in `runner_factory.py` that maps internal module names to their corresponding PyPI package names.
- `_pkg_exists` now raises an `ImportError` that includes the PyPI package name and an actionable `pip install` command (e.g. `pip install launchdarkly-server-sdk-ai-openai`).
- Simplified the warning log in `_get_provider_factory` — it now forwards the `ImportError` message directly, which already contains the install guidance.
- Added `tests/test_runner_factory.py` covering `_pkg_exists`, `_PYPI_PACKAGE_NAMES`, and `_get_provider_factory` warning content.

**Before:**
```
WARNING:ldclient.util:Could not load provider 'openai': Package 'ldai_openai' not found. Make sure the corresponding package is installed.
```

**After:**
```
WARNING:ldclient.util:Could not load provider 'openai': Package 'launchdarkly-server-sdk-ai-openai' not found. Run: pip install launchdarkly-server-sdk-ai-openai
```

## Test plan

- [x] All existing tests pass (`uv run pytest tests/ -x -q` — 185 passed)
- [x] New `tests/test_runner_factory.py` verifies the PyPI name appears in both the `ImportError` and the warning log for `openai` and `langchain` providers
- [x] Verified the old boilerplate "Make sure the corresponding package is installed" text is no longer present in warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts ImportError/warning messaging when optional provider dependencies are absent and adds unit tests; no runtime behavior changes when providers are installed.
> 
> **Overview**
> Improves provider-load failure messaging in `RunnerFactory` by introducing a `_PYPI_PACKAGE_NAMES` mapping and emitting errors that reference the *pip-installable* package names (instead of internal module names) when `ldai_openai`/`ldai_langchain` aren’t importable.
> 
> Simplifies `_get_provider_factory`’s ImportError warning to log the exception message directly, and adds `test_runner_factory.py` to validate the mapping and that warnings/errors include PyPI names and remain package-manager agnostic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a872281ea28cae80ce0f0819265d5726fbcc693c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->