### PR TITLE
fix: build judge input as string; strip legacy judge config messages

### DIFF
--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
@@ -33,7 +33,7 @@ class LangChainAgentRunner(Runner):
 
     async def run(
         self,
-        input: Any,
+        input: str,
         output_type: Optional[Dict[str, Any]] = None,
     ) -> RunnerResult:
         """
@@ -42,7 +42,7 @@ class LangChainAgentRunner(Runner):
         Delegates to the compiled LangChain agent, which handles
         the tool-calling loop internally.
 
-        :param input: The user prompt or input to the agent
+        :param input: The user prompt string to the agent
         :param output_type: Reserved for future structured output support;
             currently ignored.
         :return: :class:`RunnerResult` with ``content``, ``raw`` response, and

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
@@ -37,36 +37,24 @@ class LangChainModelRunner(Runner):
 
     async def run(
         self,
-        input: Any,
+        input: str,
         output_type: Optional[Dict[str, Any]] = None,
     ) -> RunnerResult:
         """
         Run the LangChain model with the given input.
 
-        :param input: A string prompt or a list of :class:`LDMessage` objects
+        :param input: A string prompt
         :param output_type: Optional JSON schema dict requesting structured output.
             When provided, ``parsed`` on the returned :class:`RunnerResult` is
             populated with the parsed JSON document.
         :return: :class:`RunnerResult` containing ``content``, ``metrics``,
             ``raw`` and (when ``output_type`` is set) ``parsed``.
         """
-        messages = self._coerce_input(input)
+        messages = [LDMessage(role='user', content=input)]
 
         if output_type is not None:
             return await self._run_structured(messages, output_type)
         return await self._run_completion(messages)
-
-    # convert_messages_to_langchain only accepts List[LDMessage]; _coerce_input
-    # normalizes a bare string to [LDMessage(role='user', ...)] before that step.
-    @staticmethod
-    def _coerce_input(input: Any) -> List[LDMessage]:
-        if isinstance(input, str):
-            return [LDMessage(role='user', content=input)]
-        if isinstance(input, list):
-            return input
-        raise TypeError(
-            f"Unsupported input type for LangChainModelRunner.run: {type(input).__name__}"
-        )
 
     async def _run_completion(self, messages: List[LDMessage]) -> RunnerResult:
         try:

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
@@ -24,8 +24,9 @@ class LangChainModelRunner(Runner):
     :meth:`run`.
     """
 
-    def __init__(self, llm: BaseChatModel):
+    def __init__(self, llm: BaseChatModel, config_messages: Optional[List[LDMessage]] = None):
         self._llm = llm
+        self._config_messages: List[LDMessage] = list(config_messages or [])
 
     def get_llm(self) -> BaseChatModel:
         """
@@ -43,6 +44,9 @@ class LangChainModelRunner(Runner):
         """
         Run the LangChain model with the given input.
 
+        Prepends any config messages (system prompt, instructions, etc.) stored
+        at construction time before the user message.
+
         :param input: A string prompt
         :param output_type: Optional JSON schema dict requesting structured output.
             When provided, ``parsed`` on the returned :class:`RunnerResult` is
@@ -50,7 +54,7 @@ class LangChainModelRunner(Runner):
         :return: :class:`RunnerResult` containing ``content``, ``metrics``,
             ``raw`` and (when ``output_type`` is set) ``parsed``.
         """
-        messages = [LDMessage(role='user', content=input)]
+        messages = self._config_messages + [LDMessage(role='user', content=input)]
 
         if output_type is not None:
             return await self._run_structured(messages, output_type)

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_runner_factory.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_runner_factory.py
@@ -69,4 +69,5 @@ class LangChainRunnerFactory(AIProvider):
         :return: LangChainModelRunner ready to invoke the model
         """
         llm = create_langchain_model(config)
-        return LangChainModelRunner(llm)
+        config_messages = list(getattr(config, 'messages', None) or [])
+        return LangChainModelRunner(llm, config_messages)

--- a/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
@@ -233,8 +233,7 @@ class TestRunCompletion:
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
         provider = LangChainModelRunner(mock_llm)
 
-        messages = [LDMessage(role='user', content='Hello')]
-        result = await provider.run(messages)
+        result = await provider.run('Hello')
 
         assert result.metrics.success is True
         assert result.content == 'Test response'
@@ -246,8 +245,7 @@ class TestRunCompletion:
         mock_llm.ainvoke = AsyncMock(return_value=mock_response)
         provider = LangChainModelRunner(mock_llm)
 
-        messages = [LDMessage(role='user', content='Hello')]
-        result = await provider.run(messages)
+        result = await provider.run('Hello')
 
         assert result.metrics.success is False
         assert result.content == ''
@@ -259,8 +257,7 @@ class TestRunCompletion:
         mock_llm.ainvoke = AsyncMock(side_effect=error)
         provider = LangChainModelRunner(mock_llm)
 
-        messages = [LDMessage(role='user', content='Hello')]
-        result = await provider.run(messages)
+        result = await provider.run('Hello')
 
         assert result.metrics.success is False
         assert result.content == ''
@@ -284,9 +281,8 @@ class TestRunStructured:
         mock_llm.with_structured_output = MagicMock(return_value=mock_structured_llm)
         provider = LangChainModelRunner(mock_llm)
 
-        messages = [LDMessage(role='user', content='Hello')]
         response_structure = {'type': 'object', 'properties': {}}
-        result = await provider.run(messages, output_type=response_structure)
+        result = await provider.run('Hello', output_type=response_structure)
 
         assert result.metrics.success is True
         assert result.parsed == parsed_data
@@ -300,9 +296,8 @@ class TestRunStructured:
         mock_llm.with_structured_output = MagicMock(return_value=mock_structured_llm)
         provider = LangChainModelRunner(mock_llm)
 
-        messages = [LDMessage(role='user', content='Hello')]
         response_structure = {'type': 'object', 'properties': {}}
-        result = await provider.run(messages, output_type=response_structure)
+        result = await provider.run('Hello', output_type=response_structure)
 
         assert result.metrics.success is False
         assert result.parsed is None

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_runner.py
@@ -47,7 +47,7 @@ class OpenAIAgentRunner(Runner):
 
     async def run(
         self,
-        input: Any,
+        input: str,
         output_type: Optional[Dict[str, Any]] = None,
     ) -> RunnerResult:
         """
@@ -56,7 +56,7 @@ class OpenAIAgentRunner(Runner):
         Delegates to the OpenAI Agents SDK ``Runner.run``, which handles the
         tool-calling loop internally.
 
-        :param input: The user prompt or input to the agent
+        :param input: The user prompt string to the agent
         :param output_type: Reserved for future structured output support;
             currently ignored.
         :return: :class:`RunnerResult` with ``content``, ``raw`` response, and

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_model_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_model_runner.py
@@ -35,38 +35,24 @@ class OpenAIModelRunner(Runner):
 
     async def run(
         self,
-        input: Any,
+        input: str,
         output_type: Optional[Dict[str, Any]] = None,
     ) -> RunnerResult:
         """
         Run the OpenAI model with the given input.
 
-        :param input: A string prompt or a list of :class:`LDMessage` objects
+        :param input: A string prompt
         :param output_type: Optional JSON schema dict requesting structured output.
             When provided, ``parsed`` on the returned :class:`RunnerResult` is
             populated with the parsed JSON document.
         :return: :class:`RunnerResult` containing ``content``, ``metrics``,
             ``raw`` and (when ``output_type`` is set) ``parsed``.
         """
-        try:
-            messages = self._coerce_input(input)
-        except TypeError as error:
-            log.warning(f'OpenAI model runner received unsupported input type: {error}')
-            return RunnerResult(content='', metrics=LDAIMetrics(success=False, usage=None))
+        messages = [LDMessage(role='user', content=input)]
 
         if output_type is not None:
             return await self._run_structured(messages, output_type)
         return await self._run_completion(messages)
-
-    @staticmethod
-    def _coerce_input(input: Any) -> List[LDMessage]:
-        if isinstance(input, str):
-            return [LDMessage(role='user', content=input)]
-        if isinstance(input, list):
-            return input
-        raise TypeError(
-            f"Unsupported input type for OpenAIModelRunner.run: {type(input).__name__}"
-        )
 
     async def _run_completion(self, messages: List[LDMessage]) -> RunnerResult:
         try:

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_model_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_model_runner.py
@@ -28,10 +28,12 @@ class OpenAIModelRunner(Runner):
         client: AsyncOpenAI,
         model_name: str,
         parameters: Dict[str, Any],
+        config_messages: Optional[List[LDMessage]] = None,
     ):
         self._client = client
         self._model_name = model_name
         self._parameters = parameters
+        self._config_messages: List[LDMessage] = list(config_messages or [])
 
     async def run(
         self,
@@ -41,6 +43,9 @@ class OpenAIModelRunner(Runner):
         """
         Run the OpenAI model with the given input.
 
+        Prepends any config messages (system prompt, instructions, etc.) stored
+        at construction time before the user message.
+
         :param input: A string prompt
         :param output_type: Optional JSON schema dict requesting structured output.
             When provided, ``parsed`` on the returned :class:`RunnerResult` is
@@ -48,7 +53,7 @@ class OpenAIModelRunner(Runner):
         :return: :class:`RunnerResult` containing ``content``, ``metrics``,
             ``raw`` and (when ``output_type`` is set) ``parsed``.
         """
-        messages = [LDMessage(role='user', content=input)]
+        messages = self._config_messages + [LDMessage(role='user', content=input)]
 
         if output_type is not None:
             return await self._run_structured(messages, output_type)

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_runner_factory.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_runner_factory.py
@@ -100,7 +100,8 @@ class OpenAIRunnerFactory(AIProvider):
         tool_defs = parameters.pop('tools', None) or []
         if tool_defs:
             parameters['tools'] = normalize_tool_types(tool_defs)
-        return OpenAIModelRunner(self._client, model_name, parameters)
+        config_messages = list(getattr(config, 'messages', None) or [])
+        return OpenAIModelRunner(self._client, model_name, parameters, config_messages)
 
     def get_client(self) -> AsyncOpenAI:
         """

--- a/packages/ai-providers/server-ai-openai/tests/test_openai_provider.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_openai_provider.py
@@ -4,8 +4,6 @@ import pytest
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
-from ldai import LDMessage
-
 from ldai_openai import OpenAIModelRunner, OpenAIRunnerFactory, get_ai_metrics_from_response, get_ai_usage_from_response
 
 
@@ -143,8 +141,7 @@ class TestRunCompletion:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Hello!')]
-        result = await provider.run(messages)
+        result = await provider.run('Hello!')
 
         mock_client.chat.completions.create.assert_called_once_with(
             model='gpt-3.5-turbo',
@@ -172,8 +169,7 @@ class TestRunCompletion:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Hello!')]
-        result = await provider.run(messages)
+        result = await provider.run('Hello!')
 
         assert result.content == ''
         assert result.metrics.success is False
@@ -190,8 +186,7 @@ class TestRunCompletion:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Hello!')]
-        result = await provider.run(messages)
+        result = await provider.run('Hello!')
 
         assert result.content == ''
         assert result.metrics.success is False
@@ -204,8 +199,7 @@ class TestRunCompletion:
         mock_client.chat.completions.create = AsyncMock(side_effect=Exception('API Error'))
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Hello!')]
-        result = await provider.run(messages)
+        result = await provider.run('Hello!')
 
         assert result.content == ''
         assert result.metrics.success is False
@@ -234,7 +228,6 @@ class TestRunStructured:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Tell me about a person')]
         response_structure = {
             'type': 'object',
             'properties': {
@@ -245,7 +238,7 @@ class TestRunStructured:
             'required': ['name', 'age', 'city'],
         }
 
-        result = await provider.run(messages, output_type=response_structure)
+        result = await provider.run('Tell me about a person', output_type=response_structure)
 
         assert result.parsed == {'name': 'John', 'age': 30, 'city': 'New York'}
         assert result.content == '{"name": "John", "age": 30, "city": "New York"}'
@@ -269,10 +262,9 @@ class TestRunStructured:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Tell me about a person')]
         response_structure = {'type': 'object'}
 
-        result = await provider.run(messages, output_type=response_structure)
+        result = await provider.run('Tell me about a person', output_type=response_structure)
 
         assert result.parsed is None
         assert result.content == ''
@@ -293,10 +285,9 @@ class TestRunStructured:
         mock_client.chat.completions.create = AsyncMock(return_value=mock_response)
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Tell me about a person')]
         response_structure = {'type': 'object'}
 
-        result = await provider.run(messages, output_type=response_structure)
+        result = await provider.run('Tell me about a person', output_type=response_structure)
 
         assert result.parsed is None
         assert result.content == 'invalid json content'
@@ -312,10 +303,9 @@ class TestRunStructured:
         mock_client.chat.completions.create = AsyncMock(side_effect=Exception('API Error'))
 
         provider = OpenAIModelRunner(mock_client, 'gpt-3.5-turbo', {})
-        messages = [LDMessage(role='user', content='Tell me about a person')]
         response_structure = {'type': 'object'}
 
-        result = await provider.run(messages, output_type=response_structure)
+        result = await provider.run('Tell me about a person', output_type=response_structure)
 
         assert result.parsed is None
         assert result.content == ''

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -9,7 +9,7 @@ from ldclient.client import LDClient
 from ldai import log
 from ldai.agent_graph import AgentGraphDefinition
 from ldai.evaluator import Evaluator
-from ldai.judge import Judge
+from ldai.judge import Judge, _strip_legacy_judge_messages
 from ldai.managed_agent import ManagedAgent
 from ldai.managed_agent_graph import ManagedAgentGraph
 from ldai.managed_model import ManagedModel
@@ -236,6 +236,10 @@ class LDAIClient:
             return None
 
         evaluation_metric_key = _extract_evaluation_metric_key(variation)
+
+        # strip legacy judge template messages before creating config
+        if messages:
+            messages = _strip_legacy_judge_messages(messages)
 
         config = AIJudgeConfig(
             key=key,

--- a/packages/sdk/server-ai/src/ldai/judge/__init__.py
+++ b/packages/sdk/server-ai/src/ldai/judge/__init__.py
@@ -1,15 +1,37 @@
 """Judge implementation for AI evaluation."""
 
 import random
-from typing import Any, Dict, Optional, Tuple
-
-import chevron
+from typing import Any, Dict, List, Optional, Tuple
 
 from ldai import log
 from ldai.judge.evaluation_schema_builder import EvaluationSchemaBuilder
 from ldai.models import AIJudgeConfig, LDMessage
 from ldai.providers.runner import Runner
 from ldai.providers.types import JudgeResult, RunnerResult
+
+
+def _strip_legacy_judge_messages(messages: List[LDMessage]) -> List[LDMessage]:
+    """
+    Remove legacy judge template messages from a message list.
+
+    Strips any non-system message whose content contains ``{{message_history}}``
+    or ``{{response_to_evaluate}}``.  These were used by older judge configs to
+    indicate where the SDK should interpolate the evaluated conversation; new
+    configs omit them entirely and rely on the string input built by
+    :meth:`Judge._build_evaluation_input`.
+
+    :param messages: The raw message list from the judge AI config.
+    :return: A new list with legacy template messages removed.
+    """
+    result = []
+    for msg in messages:
+        if msg.role != 'system' and (
+            '{{message_history}}' in msg.content
+            or '{{response_to_evaluate}}' in msg.content
+        ):
+            continue
+        result.append(msg)
+    return result
 
 
 class Judge:
@@ -65,11 +87,6 @@ class Judge:
                 judge_result.error_message = 'Judge configuration is missing required evaluationMetricKey'
                 return judge_result
 
-            if not self._ai_config.messages:
-                log.warning('Judge configuration must include messages')
-                judge_result.error_message = 'Judge configuration must include messages'
-                return judge_result
-
             if random.random() > effective_rate:
                 log.debug(f'Judge evaluation skipped due to sampling rate: {effective_rate}')
                 return judge_result
@@ -77,12 +94,12 @@ class Judge:
             judge_result.sampled = True
 
             tracker = self._ai_config.create_tracker()
-            messages = self._construct_evaluation_messages(input_text, output_text)
+            evaluation_input = self._build_evaluation_input(input_text, output_text)
             assert self._evaluation_response_structure is not None
 
             response = await tracker.track_metrics_of_async(
                 lambda result: result.metrics,
-                lambda: self._model_runner.run(messages, output_type=self._evaluation_response_structure),
+                lambda: self._model_runner.run(evaluation_input, output_type=self._evaluation_response_structure),
             )
 
             if response.parsed is None:
@@ -142,38 +159,21 @@ class Judge:
         """
         return self._model_runner
 
-    def _construct_evaluation_messages(self, input_text: str, output_text: str) -> list[LDMessage]:
+    def _build_evaluation_input(self, input_text: str, output_text: str) -> str:
         """
-        Constructs evaluation messages by combining judge's config messages with input/output.
+        Build the string input for the judge runner.
 
-        :param input_text: The input text
+        Legacy messages (assistant/user messages containing ``{{message_history}}``
+        or ``{{response_to_evaluate}}``) are stripped from the config; the runner
+        was already created from the judge AI config (which carries the system
+        message), so only the plain-text evaluation payload is needed here.
+
+        :param input_text: The input text (message history)
         :param output_text: The output text to evaluate
-        :return: List of messages for evaluation
+        :return: Formatted evaluation input string
         """
-        if not self._ai_config.messages:
-            return []
-
-        messages: list[LDMessage] = []
-        for msg in self._ai_config.messages:
-            # Interpolate message content with reserved variables
-            content = self._interpolate_message(msg.content, {
-                'message_history': input_text,
-                'response_to_evaluate': output_text,
-            })
-            messages.append(LDMessage(role=msg.role, content=content))
-
-        return messages
-
-    def _interpolate_message(self, content: str, variables: Dict[str, str]) -> str:
-        """
-        Interpolates message content with variables using Mustache templating.
-
-        :param content: The message content template
-        :param variables: Variables to interpolate
-        :return: Interpolated message content
-        """
-        # Use chevron (Mustache) for templating, with no escaping
-        return chevron.render(content, variables)
+        _strip_legacy_judge_messages(self._ai_config.messages or [])
+        return f"MESSAGE HISTORY:\n{input_text}\n\nRESPONSE TO EVALUATE:\n{output_text}"
 
     def _parse_evaluation_response(self, data: Dict[str, Any]) -> Optional[Tuple[float, str]]:
         """

--- a/packages/sdk/server-ai/src/ldai/judge/__init__.py
+++ b/packages/sdk/server-ai/src/ldai/judge/__init__.py
@@ -160,19 +160,6 @@ class Judge:
         return self._model_runner
 
     def _build_evaluation_input(self, input_text: str, output_text: str) -> str:
-        """
-        Build the string input for the judge runner.
-
-        Legacy messages (assistant/user messages containing ``{{message_history}}``
-        or ``{{response_to_evaluate}}``) are stripped from the config; the runner
-        was already created from the judge AI config (which carries the system
-        message), so only the plain-text evaluation payload is needed here.
-
-        :param input_text: The input text (message history)
-        :param output_text: The output text to evaluate
-        :return: Formatted evaluation input string
-        """
-        _strip_legacy_judge_messages(self._ai_config.messages or [])
         return f"MESSAGE HISTORY:\n{input_text}\n\nRESPONSE TO EVALUATE:\n{output_text}"
 
     def _parse_evaluation_response(self, data: Dict[str, Any]) -> Optional[Tuple[float, str]]:

--- a/packages/sdk/server-ai/src/ldai/managed_model.py
+++ b/packages/sdk/server-ai/src/ldai/managed_model.py
@@ -43,12 +43,9 @@ class ManagedModel:
         user_message = LDMessage(role='user', content=prompt)
         self._messages.append(user_message)
 
-        config_messages = self._ai_config.messages or []
-        all_messages = config_messages + self._messages
-
         result: RunnerResult = await tracker.track_metrics_of_async(
             lambda r: r.metrics,
-            lambda: self._model_runner.run(all_messages),
+            lambda: self._model_runner.run(prompt),
         )
 
         assistant_message = LDMessage(role='assistant', content=result.content)

--- a/packages/sdk/server-ai/src/ldai/providers/runner.py
+++ b/packages/sdk/server-ai/src/ldai/providers/runner.py
@@ -16,13 +16,13 @@ class Runner(Protocol):
 
     async def run(
         self,
-        input: Any,
+        input: str,
         output_type: Optional[Dict[str, Any]] = None,
     ) -> RunnerResult:
         """
-        Execute the runner with the given input.
+        Execute the runner with the given input string.
 
-        :param input: The input to the runner.
+        :param input: The string input to the runner.
         :param output_type: Optional JSON schema for structured output.
         :return: RunnerResult containing content, metrics, raw, and parsed fields.
         """

--- a/packages/sdk/server-ai/tests/test_judge.py
+++ b/packages/sdk/server-ai/tests/test_judge.py
@@ -1,12 +1,12 @@
 """Tests for Judge functionality."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import pytest
 from ldclient import Config, Context, LDClient
 from ldclient.integrations.test_data import TestData
 
-from ldai.judge import Judge
+from ldai.judge import Judge, _strip_legacy_judge_messages
 from ldai.judge.evaluation_schema_builder import EvaluationSchemaBuilder
 from ldai.models import (
     AIJudgeConfig,
@@ -107,8 +107,71 @@ def judge_config_without_key(tracker) -> AIJudgeConfig:
 
 @pytest.fixture
 def judge_config_without_messages(tracker) -> AIJudgeConfig:
-    """Create a judge config without messages."""
+    """Create a judge config without messages (None)."""
     return _make_judge_config(messages=None, tracker=tracker)
+
+
+class TestStripLegacyJudgeMessages:
+    """Tests for the _strip_legacy_judge_messages helper."""
+
+    def test_strips_assistant_message_with_message_history(self):
+        """Non-system messages containing {{message_history}} should be removed."""
+        messages = [
+            LDMessage(role='system', content='You are a judge.'),
+            LDMessage(role='assistant', content='Here is the history: {{message_history}}'),
+        ]
+        result = _strip_legacy_judge_messages(messages)
+        assert len(result) == 1
+        assert result[0].role == 'system'
+
+    def test_strips_user_message_with_response_to_evaluate(self):
+        """Non-system messages containing {{response_to_evaluate}} should be removed."""
+        messages = [
+            LDMessage(role='system', content='You are a judge.'),
+            LDMessage(role='user', content='Evaluate: {{response_to_evaluate}}'),
+        ]
+        result = _strip_legacy_judge_messages(messages)
+        assert len(result) == 1
+        assert result[0].role == 'system'
+
+    def test_strips_all_legacy_messages(self):
+        """All non-system template messages should be stripped from a typical legacy config."""
+        messages = [
+            LDMessage(role='system', content='You are a judge.'),
+            LDMessage(role='assistant', content='{{message_history}}'),
+            LDMessage(role='user', content='{{response_to_evaluate}}'),
+        ]
+        result = _strip_legacy_judge_messages(messages)
+        assert len(result) == 1
+        assert result[0].role == 'system'
+
+    def test_does_not_strip_system_message_containing_template_vars(self):
+        """System messages are never stripped, even if they contain template variable names."""
+        messages = [
+            LDMessage(role='system', content='Judge using {{message_history}} and {{response_to_evaluate}}.'),
+        ]
+        result = _strip_legacy_judge_messages(messages)
+        assert len(result) == 1
+        assert result[0].role == 'system'
+
+    def test_does_not_strip_non_template_messages(self):
+        """Non-system messages without template variables are left untouched."""
+        messages = [
+            LDMessage(role='system', content='You are a judge.'),
+            LDMessage(role='user', content='This is a regular message.'),
+        ]
+        result = _strip_legacy_judge_messages(messages)
+        assert len(result) == 2
+
+    def test_returns_empty_list_for_empty_input(self):
+        """An empty input list should return an empty list."""
+        assert _strip_legacy_judge_messages([]) == []
+
+    def test_new_style_config_system_only_unchanged(self):
+        """A new-style config with only a system message passes through unchanged."""
+        messages = [LDMessage(role='system', content='You are a judge.')]
+        result = _strip_legacy_judge_messages(messages)
+        assert result == messages
 
 
 class TestJudgeInitialization:
@@ -160,18 +223,104 @@ class TestJudgeEvaluate:
         mock_runner.run.assert_not_called()
 
     @pytest.mark.asyncio
-    async def test_evaluate_returns_failure_when_messages_missing(
-        self, judge_config_without_messages: AIJudgeConfig, mock_runner
+    async def test_evaluate_succeeds_when_messages_is_none(
+        self, judge_config_without_messages: AIJudgeConfig, tracker: LDAIConfigTracker, mock_runner
     ):
-        """Evaluate should return a failed JudgeResult when messages are missing."""
-        judge = Judge(judge_config_without_messages, mock_runner)
+        """Evaluate should proceed (not error early) when messages is None."""
+        mock_response = RunnerResult(
+            content='',
+            metrics=LDAIMetrics(success=True),
+            parsed={'score': 0.7, 'reasoning': 'Acceptable response.'},
+        )
+        mock_runner.run.return_value = mock_response
+        tracker.track_metrics_of_async = AsyncMock(return_value=mock_response)
+
+        config = _make_judge_config(messages=None, tracker=tracker)
+        judge = Judge(config, mock_runner)
 
         result = await judge.evaluate("input text", "output text")
 
         assert isinstance(result, JudgeResult)
-        assert result.success is False
-        assert result.sampled is False
-        mock_runner.run.assert_not_called()
+        assert result.sampled is True
+
+    @pytest.mark.asyncio
+    async def test_evaluate_passes_string_input_to_runner(
+        self, judge_config_with_key: AIJudgeConfig, tracker: LDAIConfigTracker, mock_runner
+    ):
+        """runner.run() should receive the formatted string, NOT a message list."""
+        mock_response = RunnerResult(
+            content='',
+            metrics=LDAIMetrics(success=True),
+            parsed={'score': 0.85, 'reasoning': 'Good answer.'},
+        )
+        mock_runner.run.return_value = mock_response
+        tracker.track_metrics_of_async = AsyncMock(
+            side_effect=lambda _metric_fn, fn: fn()
+        )
+
+        judge = Judge(judge_config_with_key, mock_runner)
+        await judge.evaluate("What is AI?", "AI is artificial intelligence.")
+
+        mock_runner.run.assert_called_once()
+        call_args = mock_runner.run.call_args
+        input_arg = call_args[0][0] if call_args[0] else call_args[1].get('input')
+        assert isinstance(input_arg, str)
+        assert "MESSAGE HISTORY:\nWhat is AI?" in input_arg
+        assert "RESPONSE TO EVALUATE:\nAI is artificial intelligence." in input_arg
+
+    @pytest.mark.asyncio
+    async def test_evaluate_string_input_format(
+        self, judge_config_with_key: AIJudgeConfig, tracker: LDAIConfigTracker, mock_runner
+    ):
+        """runner.run() should receive the exact expected string format."""
+        mock_response = RunnerResult(
+            content='',
+            metrics=LDAIMetrics(success=True),
+            parsed={'score': 0.9, 'reasoning': 'Correct.'},
+        )
+        mock_runner.run.return_value = mock_response
+        tracker.track_metrics_of_async = AsyncMock(
+            side_effect=lambda _metric_fn, fn: fn()
+        )
+
+        judge = Judge(judge_config_with_key, mock_runner)
+        await judge.evaluate("hello", "world")
+
+        call_args = mock_runner.run.call_args
+        input_arg = call_args[0][0] if call_args[0] else call_args[1].get('input')
+        expected = "MESSAGE HISTORY:\nhello\n\nRESPONSE TO EVALUATE:\nworld"
+        assert input_arg == expected
+
+    @pytest.mark.asyncio
+    async def test_evaluate_legacy_config_strips_template_messages(
+        self, tracker: LDAIConfigTracker, mock_runner
+    ):
+        """Legacy config with assistant/user template messages: runner still gets string input."""
+        legacy_messages = [
+            LDMessage(role='system', content='You are a strict judge.'),
+            LDMessage(role='assistant', content='{{message_history}}'),
+            LDMessage(role='user', content='Evaluate: {{response_to_evaluate}}'),
+        ]
+        config = _make_judge_config(messages=legacy_messages, tracker=tracker)
+
+        mock_response = RunnerResult(
+            content='',
+            metrics=LDAIMetrics(success=True),
+            parsed={'score': 0.75, 'reasoning': 'Mostly relevant.'},
+        )
+        mock_runner.run.return_value = mock_response
+        tracker.track_metrics_of_async = AsyncMock(
+            side_effect=lambda _metric_fn, fn: fn()
+        )
+
+        judge = Judge(config, mock_runner)
+        await judge.evaluate("input", "output")
+
+        call_args = mock_runner.run.call_args
+        input_arg = call_args[0][0] if call_args[0] else call_args[1].get('input')
+        assert isinstance(input_arg, str)
+        assert "MESSAGE HISTORY:\ninput" in input_arg
+        assert "RESPONSE TO EVALUATE:\noutput" in input_arg
 
     @pytest.mark.asyncio
     async def test_evaluate_success_with_valid_response(

--- a/packages/sdk/server-ai/tests/test_judge.py
+++ b/packages/sdk/server-ai/tests/test_judge.py
@@ -292,10 +292,14 @@ class TestJudgeEvaluate:
         assert input_arg == expected
 
     @pytest.mark.asyncio
-    async def test_evaluate_legacy_config_strips_template_messages(
+    async def test_evaluate_legacy_config_passes_string_input_to_runner(
         self, tracker: LDAIConfigTracker, mock_runner
     ):
-        """Legacy config with assistant/user template messages: runner still gets string input."""
+        """
+        Judge built directly with legacy messages (bypassing the client) still passes
+        a formatted string to the runner.  Legacy message stripping is the client's
+        responsibility; the Judge itself does not strip.
+        """
         legacy_messages = [
             LDMessage(role='system', content='You are a strict judge.'),
             LDMessage(role='assistant', content='{{message_history}}'),


### PR DESCRIPTION
## Summary

- **String input instead of message list**: `Judge.evaluate()` now calls `runner.run(input_str)` with a plain string (`"MESSAGE HISTORY:\n...\n\nRESPONSE TO EVALUATE:\n..."`) instead of constructing and passing a `List[LDMessage]`.
- **Backwards-compatible legacy message stripping**: A new `_strip_legacy_judge_messages()` helper transparently removes the old assistant/user template messages (`{{message_history}}` / `{{response_to_evaluate}}`) that appeared in older judge configs. System messages are never stripped.
- **`Runner.run` narrowed to `str`**: The `Runner` protocol and all four runner implementations (`OpenAIModelRunner`, `LangChainModelRunner`, `OpenAIAgentRunner`, `LangChainAgentRunner`) now declare `input: str`. The `_coerce_input` list-handling path in the model runners has been removed.
- **`messages` guard removed**: The early-exit guard that returned an error when `messages` was `None` or empty has been removed — configs without messages (new-style) are now handled gracefully.
- **`chevron` / `_interpolate_message` removed from judge**: The Mustache interpolation code is gone from `judge/__init__.py`; `chevron` remains a dependency because it is still used in `client.py`.

## Why

Passing a message list through the runner added unnecessary complexity and required all runners to handle both `str` and `List[LDMessage]` inputs. Moving to a single string interface simplifies the runner contract, aligns with the direction of new judge configs (system-message-only), and removes the Mustache templating requirement from the judge path.

## Test plan

- [ ] `TestStripLegacyJudgeMessages` — unit tests for the helper covering: strip assistant/user template messages, preserve system messages even with template vars, pass-through non-template messages, empty list, new-style system-only config
- [ ] `TestJudgeEvaluate::test_evaluate_passes_string_input_to_runner` — verifies `runner.run()` receives a `str`, not a list
- [ ] `TestJudgeEvaluate::test_evaluate_string_input_format` — verifies exact `"MESSAGE HISTORY:\n...\n\nRESPONSE TO EVALUATE:\n..."` format
- [ ] `TestJudgeEvaluate::test_evaluate_legacy_config_strips_template_messages` — verifies legacy configs still produce string input
- [ ] `TestJudgeEvaluate::test_evaluate_succeeds_when_messages_is_none` — verifies no early-exit error for `None` messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it narrows the `Runner.run` contract to `str` and changes how prompts/config messages are assembled, which can break callers that passed `List[LDMessage]` and alter judge/model prompting behavior.
> 
> **Overview**
> **Standardizes runner inputs to plain strings.** The `Runner` protocol and OpenAI/LangChain model + agent runners now declare `run(input: str, ...)`, removing support for passing `List[LDMessage]` and deleting the `_coerce_input` paths.
> 
> **Moves config prompts into runner construction.** `OpenAIRunnerFactory`/`LangChainRunnerFactory` now pass `config.messages` into their model runners, which prepend these config messages internally; `ManagedModel.run()` correspondingly passes only the user prompt string.
> 
> **Simplifies judge prompting and adds legacy-config cleanup.** `Judge.evaluate()` now builds a single formatted evaluation string (`MESSAGE HISTORY` / `RESPONSE TO EVALUATE`) instead of interpolating Mustache templates into message lists, and the client strips legacy non-system template messages via new `_strip_legacy_judge_messages`; tests were updated/added to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 133bc10860b88e2ef6cc2040b708a60323546162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->