### PR TITLE
chore: skip tracking judge results that were not sampled

### DIFF
--- a/packages/sdk/server-ai/src/ldai/managed_agent.py
+++ b/packages/sdk/server-ai/src/ldai/managed_agent.py
@@ -65,6 +65,8 @@ class ManagedAgent:
         async def _run_and_track(eval_task: asyncio.Task) -> List[JudgeResult]:
             results = await eval_task
             for r in results:
+                if not r.sampled:
+                    continue
                 if r.success:
                     try:
                         tracker.track_judge_result(r)

--- a/packages/sdk/server-ai/src/ldai/managed_model.py
+++ b/packages/sdk/server-ai/src/ldai/managed_model.py
@@ -75,6 +75,8 @@ class ManagedModel:
         async def _run_and_track(eval_task: asyncio.Task) -> List[JudgeResult]:
             results = await eval_task
             for r in results:
+                if not r.sampled:
+                    continue
                 if r.success:
                     try:
                         tracker.track_judge_result(r)


### PR DESCRIPTION
## Summary

- Skip processing judge results where `r.sampled` is `False` in `ManagedModel._run_and_track`
- Prevents unsampled evaluations from being tracked unnecessarily

## Test plan

- [ ] Verify judge results with `sampled=False` are skipped without errors
- [ ] Verify judge results with `sampled=True` continue to be tracked as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a simple `sampled` gate before tracking judge results, affecting only metrics/logging for evaluations that were intentionally skipped by sampling.
> 
> **Overview**
> **Judge result tracking now ignores unsampled evaluations.** In `ManagedModel` and `ManagedAgent`, `_run_and_track` skips any `JudgeResult` where `sampled` is `False`, so only actually-executed judge runs are passed to `tracker.track_judge_result` (and related warnings).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e45e7f7852938224bf76df06969a697891526fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->