### PR TITLE
fix: always return ModelSettings from _build_model_settings

### DIFF
--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_runner.py
@@ -156,4 +156,4 @@ class OpenAIAgentRunner(Runner):
             "frequency_penalty", "presence_penalty",
         }
         kwargs = {k: v for k, v in self._parameters.items() if k in known}
-        return ModelSettings(**kwargs) if kwargs else None
+        return ModelSettings(**kwargs)


### PR DESCRIPTION
## Summary

- Remove the `if kwargs else None` guard in `OpenAIAgentRunner._build_model_settings()` so an empty `ModelSettings()` is returned instead of `None` when no parameters are set.

## Test plan

- [ ] Verify `OpenAIAgentRunner` works correctly when no model parameters are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized behavior change that removes a `None` return path; only potential impact is if downstream code relied on `model_settings=None` semantics in the Agents SDK.
> 
> **Overview**
> Ensures `OpenAIAgentRunner._build_model_settings()` always constructs and returns `ModelSettings(**kwargs)` instead of returning `None` when no known model parameters are set, so the agent is consistently initialized with a `ModelSettings` object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0138d69ccd709b98afe1a720f1cfca2222fb5fa8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->