### PR TITLE
feat!: rename LDAIMetrics.usage and AIGraphMetrics.usage to .tokens

### DIFF
--- a/packages/ai-providers/server-ai-langchain/README.md
+++ b/packages/ai-providers/server-ai-langchain/README.md
@@ -126,7 +126,7 @@ model = await ai_client.create_model("ai-config-key", context)
 if model:
     result = await model.run("Explain feature flags.")
     # Metrics are tracked automatically; access them via result.metrics
-    print(result.metrics.usage)
+    print(result.metrics.tokens)
 ```
 
 ### Static Utility Methods
@@ -155,7 +155,7 @@ from ldai_langchain.langchain_helper import get_ai_metrics_from_response
 # After getting a response from LangChain
 metrics = get_ai_metrics_from_response(ai_message)
 print(f"Success: {metrics.success}")
-print(f"Tokens used: {metrics.usage.total if metrics.usage else 'N/A'}")
+print(f"Tokens used: {metrics.tokens.total if metrics.tokens else 'N/A'}")
 ```
 
 #### Provider Name Mapping

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_agent_runner.py
@@ -59,7 +59,7 @@ class LangChainAgentRunner(Runner):
                 content=output,
                 metrics=LDAIMetrics(
                     success=True,
-                    usage=sum_token_usage_from_messages(messages),
+                    tokens=sum_token_usage_from_messages(messages),
                     tool_calls=tool_calls if tool_calls else None,
                 ),
                 raw=result,
@@ -68,7 +68,7 @@ class LangChainAgentRunner(Runner):
             log.warning(f"LangChain agent run failed: {error}")
             return RunnerResult(
                 content="",
-                metrics=LDAIMetrics(success=False, usage=None),
+                metrics=LDAIMetrics(success=False, tokens=None),
             )
 
     def get_agent(self) -> Any:

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_helper.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_helper.py
@@ -217,7 +217,7 @@ def get_ai_metrics_from_response(response: Any) -> LDAIMetrics:
     :param response: The response from a LangChain model (BaseMessage or similar)
     :return: LDAIMetrics with success status and token usage
     """
-    return LDAIMetrics(success=True, usage=get_ai_usage_from_response(response))
+    return LDAIMetrics(success=True, tokens=get_ai_usage_from_response(response))
 
 
 def get_tool_calls_from_response(response: Any) -> List[str]:

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langchain_model_runner.py
@@ -82,7 +82,7 @@ class LangChainModelRunner(Runner):
                 )
                 return RunnerResult(
                     content='',
-                    metrics=LDAIMetrics(success=False, usage=metrics.usage),
+                    metrics=LDAIMetrics(success=False, tokens=metrics.tokens),
                     raw=response,
                 )
 
@@ -91,7 +91,7 @@ class LangChainModelRunner(Runner):
             log.warning(f'LangChain model invocation failed: {error}')
             return RunnerResult(
                 content='',
-                metrics=LDAIMetrics(success=False, usage=None),
+                metrics=LDAIMetrics(success=False, tokens=None),
             )
 
     async def _run_structured(
@@ -107,11 +107,11 @@ class LangChainModelRunner(Runner):
                 log.warning(f'Structured output did not return a dict. Got: {type(response)}')
                 return RunnerResult(
                     content='',
-                    metrics=LDAIMetrics(success=False, usage=None),
+                    metrics=LDAIMetrics(success=False, tokens=None),
                 )
 
             raw_response = response.get('raw')
-            usage = None
+            tokens = None
             raw_content = ''
             if raw_response is not None:
                 if hasattr(raw_response, 'content'):
@@ -122,20 +122,20 @@ class LangChainModelRunner(Runner):
                             f'Multimodal response not supported in structured mode. '
                             f'Content type: {type(raw_response.content)}, Content: {raw_response.content}'
                         )
-                usage = get_ai_usage_from_response(raw_response)
+                tokens = get_ai_usage_from_response(raw_response)
 
             if response.get('parsing_error'):
                 log.warning('LangChain structured model invocation had a parsing error')
                 return RunnerResult(
                     content=raw_content,
-                    metrics=LDAIMetrics(success=False, usage=usage),
+                    metrics=LDAIMetrics(success=False, tokens=tokens),
                     raw=raw_response,
                 )
 
             parsed = response.get('parsed') or {}
             return RunnerResult(
                 content=raw_content,
-                metrics=LDAIMetrics(success=True, usage=usage),
+                metrics=LDAIMetrics(success=True, tokens=tokens),
                 raw=raw_response,
                 parsed=parsed,
             )
@@ -143,5 +143,5 @@ class LangChainModelRunner(Runner):
             log.warning(f'LangChain structured model invocation failed: {error}')
             return RunnerResult(
                 content='',
-                metrics=LDAIMetrics(success=False, usage=None),
+                metrics=LDAIMetrics(success=False, tokens=None),
             )

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
@@ -313,7 +313,7 @@ class LangGraphAgentGraphRunner(AgentGraphRunner):
                     success=True,
                     path=handler.path,
                     duration_ms=duration_ms,
-                    usage=total_usage if (total_usage is not None and total_usage.total > 0) else None,
+                    tokens=total_usage if (total_usage is not None and total_usage.total > 0) else None,
                     node_metrics=node_metrics,
                 ),
             )

--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_callback_handler.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_callback_handler.py
@@ -142,11 +142,11 @@ class LDMetricsCallbackHandler(BaseCallbackHandler):
         metrics = self._node_metrics.get(node_key)
         if metrics is None:
             return
-        existing = metrics.usage
+        existing = metrics.tokens
         if existing is None:
-            metrics.usage = usage
+            metrics.tokens = usage
         else:
-            metrics.usage = TokenUsage(
+            metrics.tokens = TokenUsage(
                 total=existing.total + usage.total,
                 input=existing.input + usage.input,
                 output=existing.output + usage.output,

--- a/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_langchain_provider.py
@@ -95,10 +95,10 @@ class TestGetAIMetricsFromResponse:
         result = get_ai_metrics_from_response(mock_response)
 
         assert result.success is True
-        assert result.usage is not None
-        assert result.usage.total == 100
-        assert result.usage.input == 50
-        assert result.usage.output == 50
+        assert result.tokens is not None
+        assert result.tokens.total == 100
+        assert result.tokens.input == 50
+        assert result.tokens.output == 50
 
     def test_creates_metrics_with_snake_case_token_usage(self):
         """Should create metrics with snake_case token usage keys."""
@@ -114,10 +114,10 @@ class TestGetAIMetricsFromResponse:
         result = get_ai_metrics_from_response(mock_response)
 
         assert result.success is True
-        assert result.usage is not None
-        assert result.usage.total == 150
-        assert result.usage.input == 75
-        assert result.usage.output == 75
+        assert result.tokens is not None
+        assert result.tokens.total == 150
+        assert result.tokens.input == 75
+        assert result.tokens.output == 75
 
     def test_creates_metrics_with_success_true_and_no_usage_when_metadata_missing(self):
         """Should create metrics with success=True and no usage when metadata is missing."""
@@ -126,7 +126,7 @@ class TestGetAIMetricsFromResponse:
         result = get_ai_metrics_from_response(mock_response)
 
         assert result.success is True
-        assert result.usage is None
+        assert result.tokens is None
 
     def test_usage_metadata_preferred_over_response_metadata(self):
         """usage_metadata should be used when it has non-zero counts."""
@@ -355,7 +355,7 @@ class TestRunStructured:
         assert result.metrics.success is False
         assert result.parsed is None
         assert result.raw is None
-        assert result.metrics.usage is None
+        assert result.metrics.tokens is None
 
 
 class TestGetToolCallsFromResponse:
@@ -546,10 +546,10 @@ class TestLangChainAgentRunner:
 
         assert result.content == "final answer"
         assert result.metrics.success is True
-        assert result.metrics.usage is not None
-        assert result.metrics.usage.total == 30
-        assert result.metrics.usage.input == 18
-        assert result.metrics.usage.output == 12
+        assert result.metrics.tokens is not None
+        assert result.metrics.tokens.total == 30
+        assert result.metrics.tokens.input == 18
+        assert result.metrics.tokens.output == 12
 
     @pytest.mark.asyncio
     async def test_returns_failure_when_exception_thrown(self):

--- a/packages/ai-providers/server-ai-langchain/tests/test_langgraph_callback_handler.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_langgraph_callback_handler.py
@@ -148,7 +148,7 @@ def test_on_llm_end_accumulates_tokens():
     result = _llm_result(total=15, prompt=10, completion=5)
     handler.on_llm_end(result, run_id=uuid4(), parent_run_id=node_run_id)
 
-    usage = handler.node_metrics['root-agent'].usage
+    usage = handler.node_metrics['root-agent'].tokens
     assert usage is not None
     assert usage.total == 15
     assert usage.input == 10
@@ -166,7 +166,7 @@ def test_on_llm_end_accumulates_across_multiple_calls():
     handler.on_llm_end(result1, run_id=uuid4(), parent_run_id=node_run_id)
     handler.on_llm_end(result2, run_id=uuid4(), parent_run_id=node_run_id)
 
-    usage = handler.node_metrics['root-agent'].usage
+    usage = handler.node_metrics['root-agent'].tokens
     assert usage.total == 16
     assert usage.input == 11
     assert usage.output == 5
@@ -203,7 +203,7 @@ def test_on_llm_end_camel_case_token_keys():
     )
     handler.on_llm_end(result, run_id=uuid4(), parent_run_id=node_run_id)
 
-    usage = handler.node_metrics['root-agent'].usage
+    usage = handler.node_metrics['root-agent'].tokens
     assert usage is not None
     assert usage.total == 20
     assert usage.input == 12
@@ -279,10 +279,10 @@ def test_node_metrics_includes_tokens():
 
     assert 'root-agent' in metrics
     node = metrics['root-agent']
-    assert node.usage is not None
-    assert node.usage.total == 15
-    assert node.usage.input == 10
-    assert node.usage.output == 5
+    assert node.tokens is not None
+    assert node.tokens.total == 15
+    assert node.tokens.input == 10
+    assert node.tokens.output == 5
 
 
 def test_node_metrics_includes_duration():
@@ -339,8 +339,8 @@ def test_node_metrics_multiple_nodes():
 
     assert 'root-agent' in metrics
     assert 'child-agent' in metrics
-    assert metrics['root-agent'].usage.total == 15
-    assert metrics['child-agent'].usage.total == 5
+    assert metrics['root-agent'].tokens.total == 15
+    assert metrics['child-agent'].tokens.total == 5
 
 
 def test_node_metrics_no_tool_calls_returns_none():
@@ -364,7 +364,7 @@ def test_node_metrics_no_usage_returns_none():
 
     metrics = handler.node_metrics
 
-    assert metrics['root-agent'].usage is None
+    assert metrics['root-agent'].tokens is None
 
 
 # ---------------------------------------------------------------------------

--- a/packages/ai-providers/server-ai-langchain/tests/test_tracking_langgraph.py
+++ b/packages/ai-providers/server-ai-langchain/tests/test_tracking_langgraph.py
@@ -269,10 +269,10 @@ async def test_tracks_node_and_graph_tokens_on_success():
     node_metrics = handler.node_metrics
     assert 'root-agent' in node_metrics
     node = node_metrics['root-agent']
-    assert node.usage is not None
-    assert node.usage.total == 15
-    assert node.usage.input == 10
-    assert node.usage.output == 5
+    assert node.tokens is not None
+    assert node.tokens.total == 15
+    assert node.tokens.input == 10
+    assert node.tokens.output == 5
     assert node.success is True
     assert node.duration_ms is not None
 
@@ -495,8 +495,8 @@ async def test_multi_node_tracks_per_node_tokens_and_path():
     node_metrics = handler.node_metrics
 
     # Per-node token usage is keyed by node key
-    assert node_metrics['root-agent'].usage.total == 15
-    assert node_metrics['child-agent'].usage.total == 5
+    assert node_metrics['root-agent'].tokens.total == 15
+    assert node_metrics['child-agent'].tokens.total == 5
 
     # Graph-level total from the real runner run
     ev = _events(mock_ld_client)

--- a/packages/ai-providers/server-ai-openai/README.md
+++ b/packages/ai-providers/server-ai-openai/README.md
@@ -112,7 +112,7 @@ model = await ai_client.create_model("ai-config-key", context)
 if model:
     result = await model.run("Explain feature flags.")
     # Metrics are tracked automatically; access them via result.metrics
-    print(result.metrics.usage)
+    print(result.metrics.tokens)
 ```
 
 ### Static Utility Methods
@@ -141,7 +141,7 @@ from ldai_openai import get_ai_metrics_from_response
 # After getting a response from OpenAI
 metrics = get_ai_metrics_from_response(response)
 print(f"Success: {metrics.success}")
-print(f"Tokens used: {metrics.usage.total if metrics.usage else 'N/A'}")
+print(f"Tokens used: {metrics.tokens.total if metrics.tokens else 'N/A'}")
 ```
 
 ## Documentation

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -103,7 +103,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
                     success=True,
                     path=path,
                     duration_ms=duration_ms,
-                    usage=token_usage,
+                    tokens=token_usage,
                     node_metrics=self._node_metrics,
                 ),
             )
@@ -243,7 +243,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
             src_metrics.success = True
             src_metrics.duration_ms = int(duration_ms)
             try:
-                src_metrics.usage = extract_usage_from_request_entry(
+                src_metrics.tokens = extract_usage_from_request_entry(
                     run_ctx.usage.request_usage_entries[-1]
                 )
             except Exception:
@@ -265,7 +265,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         metrics.duration_ms = int((now_ns - state.last_handoff_ns) // 1_000_000)
 
         try:
-            metrics.usage = extract_usage_from_request_entry(
+            metrics.tokens = extract_usage_from_request_entry(
                 result.context_wrapper.usage.request_usage_entries[-1]
             )
         except Exception:

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_runner.py
@@ -72,7 +72,7 @@ class OpenAIAgentRunner(Runner):
             )
             return RunnerResult(
                 content="",
-                metrics=LDAIMetrics(success=False, usage=None),
+                metrics=LDAIMetrics(success=False, tokens=None),
             )
 
         try:
@@ -100,7 +100,7 @@ class OpenAIAgentRunner(Runner):
                 content=str(result.final_output),
                 metrics=LDAIMetrics(
                     success=True,
-                    usage=get_ai_usage_from_response(result),
+                    tokens=get_ai_usage_from_response(result),
                     tool_calls=tool_calls if tool_calls else None,
                 ),
                 raw=result,
@@ -109,7 +109,7 @@ class OpenAIAgentRunner(Runner):
             log.warning(f"OpenAI agent run failed: {error}")
             return RunnerResult(
                 content="",
-                metrics=LDAIMetrics(success=False, usage=None),
+                metrics=LDAIMetrics(success=False, tokens=None),
             )
 
     def _build_agent_tools(self) -> List[Any]:

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_helper.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_helper.py
@@ -75,7 +75,7 @@ def get_ai_metrics_from_response(response: Any) -> LDAIMetrics:
     :param response: An OpenAI chat completions response or openai-agents RunResult
     :return: LDAIMetrics with success status and token usage
     """
-    return LDAIMetrics(success=True, usage=get_ai_usage_from_response(response))
+    return LDAIMetrics(success=True, tokens=get_ai_usage_from_response(response))
 
 
 # Canonical names for OpenAI hosted tools (LD config / Chat Completions ``type``).

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_model_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_model_runner.py
@@ -79,7 +79,7 @@ class OpenAIModelRunner(Runner):
                 log.warning('OpenAI response has no content available')
                 return RunnerResult(
                     content='',
-                    metrics=LDAIMetrics(success=False, usage=metrics.usage),
+                    metrics=LDAIMetrics(success=False, tokens=metrics.tokens),
                     raw=response,
                 )
 
@@ -88,7 +88,7 @@ class OpenAIModelRunner(Runner):
             log.warning(f'OpenAI model invocation failed: {error}')
             return RunnerResult(
                 content='',
-                metrics=LDAIMetrics(success=False, usage=None),
+                metrics=LDAIMetrics(success=False, tokens=None),
             )
 
     async def _run_structured(
@@ -118,7 +118,7 @@ class OpenAIModelRunner(Runner):
                 log.warning('OpenAI structured response has no content available')
                 return RunnerResult(
                     content='',
-                    metrics=LDAIMetrics(success=False, usage=metrics.usage),
+                    metrics=LDAIMetrics(success=False, tokens=metrics.tokens),
                     raw=response,
                 )
 
@@ -134,14 +134,14 @@ class OpenAIModelRunner(Runner):
                 log.warning(f'OpenAI structured response contains invalid JSON: {parse_error}')
                 return RunnerResult(
                     content=content,
-                    metrics=LDAIMetrics(success=False, usage=metrics.usage),
+                    metrics=LDAIMetrics(success=False, tokens=metrics.tokens),
                     raw=response,
                 )
         except Exception as error:
             log.warning(f'OpenAI structured model invocation failed: {error}')
             return RunnerResult(
                 content='',
-                metrics=LDAIMetrics(success=False, usage=None),
+                metrics=LDAIMetrics(success=False, tokens=None),
             )
 
     @staticmethod

--- a/packages/ai-providers/server-ai-openai/tests/test_openai_provider.py
+++ b/packages/ai-providers/server-ai-openai/tests/test_openai_provider.py
@@ -87,10 +87,10 @@ class TestGetAIMetricsFromResponse:
         """Should create metrics with success=True and token usage."""
         result = get_ai_metrics_from_response(_make_completions_response(total=100, prompt=50, completion=50))
         assert result.success is True
-        assert result.usage is not None
-        assert result.usage.total == 100
-        assert result.usage.input == 50
-        assert result.usage.output == 50
+        assert result.tokens is not None
+        assert result.tokens.total == 100
+        assert result.tokens.input == 50
+        assert result.tokens.output == 50
 
     def test_creates_metrics_with_success_true_and_no_usage_when_usage_missing(self):
         """Should create metrics with success=True and no usage when usage is missing."""
@@ -101,7 +101,7 @@ class TestGetAIMetricsFromResponse:
         result = get_ai_metrics_from_response(mock_response)
 
         assert result.success is True
-        assert result.usage is None
+        assert result.tokens is None
 
     def test_handles_partial_usage_data(self):
         """Should handle partial usage data."""
@@ -112,10 +112,10 @@ class TestGetAIMetricsFromResponse:
         result = get_ai_metrics_from_response(mock_response)
 
         assert result.success is True
-        assert result.usage is not None
-        assert result.usage.total == 0
-        assert result.usage.input == 30
-        assert result.usage.output == 0
+        assert result.tokens is not None
+        assert result.tokens.total == 0
+        assert result.tokens.input == 30
+        assert result.tokens.output == 0
 
 
 class TestRunCompletion:
@@ -150,10 +150,10 @@ class TestRunCompletion:
 
         assert result.content == 'Hello! How can I help you today?'
         assert result.metrics.success is True
-        assert result.metrics.usage is not None
-        assert result.metrics.usage.total == 25
-        assert result.metrics.usage.input == 10
-        assert result.metrics.usage.output == 15
+        assert result.metrics.tokens is not None
+        assert result.metrics.tokens.total == 25
+        assert result.metrics.tokens.input == 10
+        assert result.metrics.tokens.output == 15
 
     @pytest.mark.asyncio
     async def test_returns_unsuccessful_response_when_no_content(self, mock_client):
@@ -298,10 +298,10 @@ class TestRunStructured:
         assert result.parsed == {'name': 'John', 'age': 30, 'city': 'New York'}
         assert result.content == '{"name": "John", "age": 30, "city": "New York"}'
         assert result.metrics.success is True
-        assert result.metrics.usage is not None
-        assert result.metrics.usage.total == 30
-        assert result.metrics.usage.input == 20
-        assert result.metrics.usage.output == 10
+        assert result.metrics.tokens is not None
+        assert result.metrics.tokens.total == 30
+        assert result.metrics.tokens.input == 20
+        assert result.metrics.tokens.output == 10
 
     @pytest.mark.asyncio
     async def test_returns_unsuccessful_when_no_content_in_structured_response(self, mock_client):
@@ -347,8 +347,8 @@ class TestRunStructured:
         assert result.parsed is None
         assert result.content == 'invalid json content'
         assert result.metrics.success is False
-        assert result.metrics.usage is not None
-        assert result.metrics.usage.total == 15
+        assert result.metrics.tokens is not None
+        assert result.metrics.tokens.total == 15
 
     @pytest.mark.asyncio
     async def test_returns_unsuccessful_response_when_exception_thrown(self, mock_client):
@@ -521,8 +521,8 @@ class TestOpenAIAgentRunner:
 
         assert result.content == "The answer is 42."
         assert result.metrics.success is True
-        assert result.metrics.usage is not None
-        assert result.metrics.usage.total == 15
+        assert result.metrics.tokens is not None
+        assert result.metrics.tokens.total == 15
 
     @pytest.mark.asyncio
     async def test_executes_tool_calls_and_returns_final_response(self):
@@ -546,7 +546,7 @@ class TestOpenAIAgentRunner:
 
         assert result.content == "It is sunny in Paris."
         assert result.metrics.success is True
-        assert result.metrics.usage.total == 43
+        assert result.metrics.tokens.total == 43
 
     @pytest.mark.asyncio
     async def test_returns_failure_when_exception_thrown(self):

--- a/packages/sdk/server-ai/README.md
+++ b/packages/sdk/server-ai/README.md
@@ -181,7 +181,7 @@ async def main():
     def map_custom_provider_metrics(response):
         return LDAIMetrics(
             success=True,
-            usage=TokenUsage(
+            tokens=TokenUsage(
                 total=response.usage.get('total_tokens', 0) if response.usage else 0,
                 input=response.usage.get('prompt_tokens', 0) if response.usage else 0,
                 output=response.usage.get('completion_tokens', 0) if response.usage else 0,

--- a/packages/sdk/server-ai/src/ldai/managed_agent_graph.py
+++ b/packages/sdk/server-ai/src/ldai/managed_agent_graph.py
@@ -82,8 +82,8 @@ class ManagedAgentGraph:
                 continue
             node_tracker = node.get_config().create_tracker()
 
-            if node_ldai_metrics.usage is not None:
-                node_tracker.track_tokens(node_ldai_metrics.usage)
+            if node_ldai_metrics.tokens is not None:
+                node_tracker.track_tokens(node_ldai_metrics.tokens)
             if node_ldai_metrics.duration_ms is not None:
                 node_tracker.track_duration(node_ldai_metrics.duration_ms)
             if node_ldai_metrics.tool_calls:

--- a/packages/sdk/server-ai/src/ldai/providers/types.py
+++ b/packages/sdk/server-ai/src/ldai/providers/types.py
@@ -20,7 +20,7 @@ class LDAIMetrics:
     success: bool
     """Whether the invocation succeeded."""
 
-    usage: Optional[TokenUsage] = None
+    tokens: Optional[TokenUsage] = None
     """Optional token usage information."""
 
     tool_calls: Optional[List[str]] = None
@@ -36,11 +36,11 @@ class LDAIMetrics:
         result: Dict[str, Any] = {
             'success': self.success,
         }
-        if self.usage is not None:
-            result['usage'] = {
-                'total': self.usage.total,
-                'input': self.usage.input,
-                'output': self.usage.output,
+        if self.tokens is not None:
+            result['tokens'] = {
+                'total': self.tokens.total,
+                'input': self.tokens.input,
+                'output': self.tokens.output,
             }
         if self.tool_calls is not None:
             result['toolCalls'] = self.tool_calls
@@ -99,7 +99,7 @@ class AIGraphMetrics:
     duration_ms: Optional[int] = None
     """Wall-clock duration of the graph run in milliseconds."""
 
-    usage: Optional[TokenUsage] = None
+    tokens: Optional[TokenUsage] = None
     """Optional aggregate token usage information across all nodes in the graph run."""
 
     node_metrics: Dict[str, LDAIMetrics] = field(default_factory=dict)
@@ -119,7 +119,7 @@ class AIGraphMetricSummary:
     duration_ms: Optional[int] = None
     """Wall-clock duration of the graph run in milliseconds."""
 
-    usage: Optional[TokenUsage] = None
+    tokens: Optional[TokenUsage] = None
     """Optional aggregate token usage information across all nodes in the graph run."""
 
     node_metrics: Dict[str, LDAIMetricSummary] = field(default_factory=dict)

--- a/packages/sdk/server-ai/src/ldai/tracker.py
+++ b/packages/sdk/server-ai/src/ldai/tracker.py
@@ -49,7 +49,7 @@ class LDAIMetricSummary:
         self._duration_ms: Optional[int] = None
         self._success: Optional[bool] = None
         self._feedback: Optional[Dict[str, FeedbackKind]] = None
-        self._usage: Optional[TokenUsage] = None
+        self._tokens: Optional[TokenUsage] = None
         self._time_to_first_token: Optional[int] = None
         self._tool_calls: List[str] = []
         self._resumption_token: Optional[str] = None
@@ -81,8 +81,8 @@ class LDAIMetricSummary:
         return self._feedback
 
     @property
-    def usage(self) -> Optional[TokenUsage]:
-        return self._usage
+    def tokens(self) -> Optional[TokenUsage]:
+        return self._tokens
 
     @property
     def time_to_first_token(self) -> Optional[int]:
@@ -305,8 +305,8 @@ class LDAIConfigTracker:
             self.track_success()
         else:
             self.track_error()
-        if metrics.usage:
-            self.track_tokens(metrics.usage)
+        if metrics.tokens:
+            self.track_tokens(metrics.tokens)
         if metrics.tool_calls is not None:
             self.track_tool_calls(metrics.tool_calls)
 
@@ -533,10 +533,10 @@ class LDAIConfigTracker:
 
         :param tokens: Token usage data from either custom, OpenAI, or Bedrock sources.
         """
-        if self._summary.usage is not None:
+        if self._summary.tokens is not None:
             log.warning("Tokens have already been tracked for this execution. %s", self.__get_track_data())
             return
-        self._summary._usage = tokens
+        self._summary._tokens = tokens
         td = self.__get_track_data()
         if tokens.total > 0:
             self._ld_client.track(
@@ -731,10 +731,10 @@ class AIGraphTracker:
         """
         if tokens is None or tokens.total <= 0:
             return
-        if self._summary.usage is not None:
+        if self._summary.tokens is not None:
             log.warning("Token usage has already been tracked for this graph execution. %s", self.__get_track_data())
             return
-        self._summary.usage = tokens
+        self._summary.tokens = tokens
         self._ld_client.track(
             "$ld:ai:graph:total_tokens",
             self._context,
@@ -840,8 +840,8 @@ class AIGraphTracker:
             self.track_invocation_failure()
         if metrics.path:
             self.track_path(metrics.path)
-        if metrics.usage is not None:
-            self.track_total_tokens(metrics.usage)
+        if metrics.tokens is not None:
+            self.track_total_tokens(metrics.tokens)
 
     def track_graph_metrics_of(
         self,

--- a/packages/sdk/server-ai/tests/test_managed_agent.py
+++ b/packages/sdk/server-ai/tests/test_managed_agent.py
@@ -30,7 +30,7 @@ def _make_noop_evaluator_config() -> MagicMock:
         return_value=RunnerResult(
             content="Test response",
             raw=None,
-            metrics=LDAIMetrics(success=True, usage=None),
+            metrics=LDAIMetrics(success=True, tokens=None),
         )
     )
     mock_tracker.get_summary = MagicMock(return_value=_make_summary(True))
@@ -85,7 +85,7 @@ class TestManagedAgentRun:
         mock_runner.run = AsyncMock(
             return_value=RunnerResult(
                 content="Test response",
-                metrics=LDAIMetrics(success=True, usage=None),
+                metrics=LDAIMetrics(success=True, tokens=None),
                 raw=None,
             )
         )
@@ -110,7 +110,7 @@ class TestManagedAgentRun:
         fresh_tracker.track_metrics_of_async = AsyncMock(
             return_value=RunnerResult(
                 content="Fresh tracker response",
-                metrics=LDAIMetrics(success=True, usage=None),
+                metrics=LDAIMetrics(success=True, tokens=None),
                 raw=None,
             )
         )
@@ -340,7 +340,7 @@ class TestLDAIClientCreateAgent:
 
         mock_runner = MagicMock()
         mock_runner.run = AsyncMock(
-            return_value=RunnerResult(content="Hello!", metrics=LDAIMetrics(success=True, usage=None), raw=None)
+            return_value=RunnerResult(content="Hello!", metrics=LDAIMetrics(success=True, tokens=None), raw=None)
         )
 
         original = rf.RunnerFactory.create_agent

--- a/packages/sdk/server-ai/tests/test_managed_agent_graph.py
+++ b/packages/sdk/server-ai/tests/test_managed_agent_graph.py
@@ -44,16 +44,16 @@ class StubRunnerWithMetrics(AgentGraphRunner):
                 success=True,
                 path=["root", "specialist"],
                 duration_ms=42,
-                usage=TokenUsage(total=10, input=5, output=5),
+                tokens=TokenUsage(total=10, input=5, output=5),
                 node_metrics={
                     "root": LDAIMetrics(
                         success=True,
-                        usage=TokenUsage(total=5, input=3, output=2),
+                        tokens=TokenUsage(total=5, input=3, output=2),
                         duration_ms=20,
                     ),
                     "specialist": LDAIMetrics(
                         success=True,
-                        usage=TokenUsage(total=5, input=2, output=3),
+                        tokens=TokenUsage(total=5, input=2, output=3),
                         duration_ms=22,
                     ),
                 },
@@ -71,7 +71,7 @@ def _make_graph_tracker_mock(runner_result):
         success=m.success,
         path=list(m.path),
         duration_ms=m.duration_ms,
-        usage=m.usage,
+        tokens=m.tokens,
     )
     mock_tracker = MagicMock()
     mock_tracker.track_graph_metrics_of_async = AsyncMock(return_value=runner_result)
@@ -120,8 +120,8 @@ async def test_managed_agent_graph_run_surfaces_graph_metrics():
     assert result.metrics.success is True
     assert result.metrics.path == ["root", "specialist"]
     assert result.metrics.duration_ms == 42
-    assert result.metrics.usage is not None
-    assert result.metrics.usage.total == 10
+    assert result.metrics.tokens is not None
+    assert result.metrics.tokens.total == 10
 
 
 @pytest.mark.asyncio

--- a/packages/sdk/server-ai/tests/test_managed_model.py
+++ b/packages/sdk/server-ai/tests/test_managed_model.py
@@ -16,7 +16,7 @@ from ldai.tracker import LDAIConfigTracker, LDAIMetricSummary
 def _make_runner_result(content: str = 'response text') -> RunnerResult:
     return RunnerResult(
         content=content,
-        metrics=LDAIMetrics(success=True, usage=None),
+        metrics=LDAIMetrics(success=True, tokens=None),
     )
 
 

--- a/packages/sdk/server-ai/tests/test_tracker.py
+++ b/packages/sdk/server-ai/tests/test_tracker.py
@@ -52,7 +52,7 @@ def test_summary_starts_empty(client: LDClient):
     assert tracker.get_summary().duration is None
     assert tracker.get_summary().feedback is None
     assert tracker.get_summary().success is None
-    assert tracker.get_summary().usage is None
+    assert tracker.get_summary().tokens is None
 
 
 def test_tracks_duration(client: LDClient):
@@ -171,7 +171,7 @@ def test_tracks_token_usage(client: LDClient):
 
     client.track.assert_has_calls(calls)  # type: ignore
 
-    assert tracker.get_summary().usage == tokens
+    assert tracker.get_summary().tokens == tokens
 
 
 def test_tracks_bedrock_metrics(client: LDClient):
@@ -209,7 +209,7 @@ def test_tracks_bedrock_metrics(client: LDClient):
 
     assert tracker.get_summary().success is True
     assert tracker.get_summary().duration == 50
-    assert tracker.get_summary().usage == TokenUsage(330, 220, 110)
+    assert tracker.get_summary().tokens == TokenUsage(330, 220, 110)
 
 
 def test_tracks_bedrock_metrics_with_error(client: LDClient):
@@ -247,7 +247,7 @@ def test_tracks_bedrock_metrics_with_error(client: LDClient):
 
     assert tracker.get_summary().success is False
     assert tracker.get_summary().duration == 50
-    assert tracker.get_summary().usage == TokenUsage(330, 220, 110)
+    assert tracker.get_summary().tokens == TokenUsage(330, 220, 110)
 
 
 def test_tracks_openai_metrics(client: LDClient):
@@ -287,7 +287,7 @@ def test_tracks_openai_metrics(client: LDClient):
 
     client.track.assert_has_calls(calls, any_order=False)  # type: ignore
 
-    assert tracker.get_summary().usage == TokenUsage(330, 220, 110)
+    assert tracker.get_summary().tokens == TokenUsage(330, 220, 110)
 
 
 def test_tracks_openai_metrics_with_exception(client: LDClient):
@@ -316,7 +316,7 @@ def test_tracks_openai_metrics_with_exception(client: LDClient):
 
     client.track.assert_has_calls(calls, any_order=False)  # type: ignore
 
-    assert tracker.get_summary().usage is None
+    assert tracker.get_summary().tokens is None
 
 
 @pytest.mark.parametrize(
@@ -511,7 +511,7 @@ def test_config_tracker_track_metrics_of(client: LDClient):
         return "done"
 
     def extract(r):
-        return LDAIMetrics(success=True, usage=TokenUsage(5, 2, 3))
+        return LDAIMetrics(success=True, tokens=TokenUsage(5, 2, 3))
 
     out = tracker.track_metrics_of(extract, fn)
     assert out == "done"
@@ -533,7 +533,7 @@ async def test_config_tracker_track_metrics_of_async_passes_graph_key(client: LD
         return "ok"
 
     def extract(r):
-        return LDAIMetrics(success=True, usage=TokenUsage(5, 2, 3))
+        return LDAIMetrics(success=True, tokens=TokenUsage(5, 2, 3))
 
     await tracker.track_metrics_of_async(extract, fn)
     gk_td = {**_base_td(), "graphKey": "gg"}
@@ -579,7 +579,7 @@ def test_ai_graph_tracker_summary_starts_empty(client: LDClient):
     assert isinstance(s, AIGraphMetricSummary)
     assert s.success is None
     assert s.duration_ms is None
-    assert s.usage is None
+    assert s.tokens is None
     assert s.path == []
 
 
@@ -595,8 +595,8 @@ def test_ai_graph_tracker_summary_populated_by_tracking(client: LDClient):
     assert s.success is True
     assert s.duration_ms == 123
     assert s.path == ["a", "b", "c"]
-    assert s.usage is not None
-    assert s.usage.total == 50
+    assert s.tokens is not None
+    assert s.tokens.total == 50
 
 
 def test_ai_graph_tracker_summary_reflects_failure(client: LDClient):
@@ -653,7 +653,7 @@ def test_ai_graph_tracker_duplicate_tokens_is_ignored(client: LDClient):
     g.track_total_tokens(TokenUsage(99, 50, 49))
     token_calls = [c for c in client.track.mock_calls if c.args[0] == "$ld:ai:graph:total_tokens"]  # type: ignore
     assert len(token_calls) == 1
-    assert g.get_summary().usage.total == 10  # type: ignore
+    assert g.get_summary().tokens.total == 10  # type: ignore
 
 
 # --- track_graph_metrics_of / track_graph_metrics_of_async tests ---
@@ -670,7 +670,7 @@ def test_track_graph_metrics_of_tracks_success(client: LDClient):
         success=True,
         path=["a", "b"],
         duration_ms=100,
-        usage=TokenUsage(10, 6, 4),
+        tokens=TokenUsage(10, 6, 4),
     )
 
     returned = g.track_graph_metrics_of(lambda r: metrics, lambda: result_obj)
@@ -756,7 +756,7 @@ async def test_track_graph_metrics_of_async_tracks_success(client: LDClient):
         success=True,
         path=["x", "y"],
         duration_ms=50,
-        usage=TokenUsage(20, 12, 8),
+        tokens=TokenUsage(20, 12, 8),
     )
 
     async def fn():
@@ -833,7 +833,7 @@ def test_duplicate_track_tokens_is_ignored(client: LDClient):
 
     # 3 track calls for total/input/output from the first call only
     assert client.track.call_count == 3  # type: ignore
-    assert tracker.get_summary().usage == tokens1
+    assert tracker.get_summary().tokens == tokens1
 
 
 def test_duplicate_track_success_is_ignored(client: LDClient):
@@ -1157,13 +1157,13 @@ def test_client_create_tracker_fails_on_invalid_json():
 def test_ldai_metrics_to_dict_includes_tool_calls_and_duration_ms():
     metrics = LDAIMetrics(
         success=True,
-        usage=TokenUsage(total=10, input=4, output=6),
+        tokens=TokenUsage(total=10, input=4, output=6),
         tool_calls=["search", "lookup"],
         duration_ms=123,
     )
     d = metrics.to_dict()
     assert d["success"] is True
-    assert d["usage"] == {"total": 10, "input": 4, "output": 6}
+    assert d["tokens"] == {"total": 10, "input": 4, "output": 6}
     assert d["toolCalls"] == ["search", "lookup"]
     assert d["durationMs"] == 123
 
@@ -1265,7 +1265,7 @@ def test_track_metrics_of_skips_track_tool_calls_when_absent(client: LDClient):
         return "done"
 
     def extract(_r):
-        return LDAIMetrics(success=True, usage=None)
+        return LDAIMetrics(success=True, tokens=None)
 
     tracker.track_metrics_of(extract, fn)
     assert tracker.get_summary().tool_calls == []


### PR DESCRIPTION
## Summary

Standardizes on `tokens` as the field name for token usage across all AI metric types, aligning with the canonical spec rename. Renames:

- `LDAIMetrics.usage` → `LDAIMetrics.tokens` (runner-level single-model metrics)
- `AIGraphMetrics.usage` → `AIGraphMetrics.tokens` (runner-level graph metrics)
- `LDAIMetricSummary.usage` → `LDAIMetricSummary.tokens` (managed-layer single-model summary)
- `AIGraphMetricSummary.usage` → `AIGraphMetricSummary.tokens` (managed-layer graph summary)

Updates the type definitions in `ldai/providers/types.py` and `ldai/tracker.py`, all internal usages across the SDK (`tracker.py`, `managed_agent_graph.py`) and provider packages (openai model + agent + agent-graph runners; langchain model + agent + langgraph runners; langgraph callback handler), tests, and README docstrings. The `to_dict()` serialization key on `LDAIMetrics` also changes from `usage` to `tokens`.

No backward-compat aliases are kept -- these types are part of the in-progress unreleased SDK iteration after PR #173 (the prior rename batch).

## Coordinated PRs

This is one of three coordinated PRs landing this rename together:

- **sdk-specs** (canonical name source): https://github.com/launchdarkly/sdk-specs/pull/163
- **python-server-sdk-ai** (this PR): targets `main`
- **js-core** (sibling impl): https://github.com/launchdarkly/js-core/pull/1366 (targets `feat/next-ai-release`)

## Test plan

- [x] `make test` -- all 325 tests pass (server-ai 196, langchain 85, openai 44)
- [x] `make lint` -- mypy, isort, pycodestyle all clean across all three packages
- [ ] e2e validation via `hello-python-ai` chat-judge example (sibling agent)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad breaking API rename from `usage` to `tokens` across SDK/provider metric types and serialization, which will require downstream code updates and could silently drop token tracking if any call sites were missed.
> 
> **Overview**
> Standardizes token accounting field names by renaming **`usage` → `tokens`** across core metric types (`LDAIMetrics`, `AIGraphMetrics`) and their managed summaries, including `LDAIMetrics.to_dict()` now emitting a `tokens` key.
> 
> Updates all affected runners (LangChain, LangGraph, OpenAI models/agents/graphs), tracker integration (`track_tokens`, graph total token tracking), docs, and tests to use the new `tokens` field with no backward-compatible alias.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccdc00ed58aa20188b2cc99526185f134e99b047. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->