### PR TITLE
feat!: narrow AgentGraphRunner.run input from Any to str

### DIFF
--- a/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py
@@ -274,7 +274,7 @@ class LangGraphAgentGraphRunner(AgentGraphRunner):
         compiled = agent_builder.compile()
         return compiled, fn_name_to_config_key, node_keys
 
-    async def run(self, input: Any) -> AgentGraphRunnerResult:
+    async def run(self, input: str) -> AgentGraphRunnerResult:
         """
         Run the agent graph with the given input.
 
@@ -295,7 +295,7 @@ class LangGraphAgentGraphRunner(AgentGraphRunner):
             handler = LDMetricsCallbackHandler(self._node_keys, self._fn_name_to_config_key)
 
             result = await self._compiled.ainvoke(  # type: ignore[call-overload]
-                {'messages': [HumanMessage(content=str(input))]},
+                {'messages': [HumanMessage(content=input)]},
                 config={'callbacks': [handler], 'recursion_limit': 25},
             )
 

--- a/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
+++ b/packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py
@@ -63,7 +63,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         self._tool_name_map: Dict[str, str] = {}
         self._node_metrics: Dict[str, LDAIMetrics] = {}
 
-    async def run(self, input: Any) -> AgentGraphRunnerResult:
+    async def run(self, input: str) -> AgentGraphRunnerResult:
         """
         Run the agent graph with the given input.
 
@@ -81,7 +81,6 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
         if root_key:
             path.append(root_key)
 
-        input_str = str(input)
         start_ns = time.perf_counter_ns()
         state = _RunState(last_handoff_ns=start_ns, last_node_key=root_key)
         try:
@@ -89,7 +88,7 @@ class OpenAIAgentGraphRunner(AgentGraphRunner):
             root_agent = self._build_agents(path, state)
             if root_key:
                 self._node_metrics[root_key] = LDAIMetrics(success=False)
-            result = await Runner.run(root_agent, input_str)
+            result = await Runner.run(root_agent, input)
             self._flush_final_segment(state, result)
             self._collect_tool_calls(result)
 

--- a/packages/sdk/server-ai/src/ldai/managed_agent_graph.py
+++ b/packages/sdk/server-ai/src/ldai/managed_agent_graph.py
@@ -1,6 +1,6 @@
 """ManagedAgentGraph — LaunchDarkly managed wrapper for agent graph execution."""
 
-from typing import Any, Dict
+from typing import Dict
 
 from ldai.agent_graph import AgentGraphDefinition
 from ldai.providers import AgentGraphRunner
@@ -38,14 +38,14 @@ class ManagedAgentGraph:
         self._graph = graph
         self._runner = runner
 
-    async def run(self, input: Any) -> ManagedGraphResult:
+    async def run(self, input: str) -> ManagedGraphResult:
         """
         Run the agent graph with the given input.
 
         Delegates to the underlying AgentGraphRunner, then drives all
         LaunchDarkly tracking from ``result.metrics``.
 
-        :param input: The input prompt or structured input for the graph
+        :param input: The user input prompt to process through the graph.
         :return: ManagedGraphResult containing the content, metric summary,
             and raw response.
         """

--- a/packages/sdk/server-ai/src/ldai/providers/agent_graph_runner.py
+++ b/packages/sdk/server-ai/src/ldai/providers/agent_graph_runner.py
@@ -1,4 +1,4 @@
-from typing import Any, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 from ldai.providers.types import AgentGraphRunnerResult
 
@@ -18,11 +18,11 @@ class AgentGraphRunner(Protocol):
     the caller just passes input.
     """
 
-    async def run(self, input: Any) -> AgentGraphRunnerResult:
+    async def run(self, input: str) -> AgentGraphRunnerResult:
         """
         Run the agent graph with the given input.
 
-        :param input: The input to the agent graph (string prompt or structured input)
+        :param input: The string prompt to send to the agent graph
         :return: AgentGraphRunnerResult containing the content, raw response, and AIGraphMetrics
         """
         ...


### PR DESCRIPTION
## Summary

Narrows the `AgentGraphRunner.run` input type from `Any` to `str` across the protocol (`server-ai`) and both concrete implementations (`server-ai-openai`, `server-ai-langchain`). Also narrows `ManagedAgentGraph.run` (which forwards directly to the runner) for type-consistency.

Brings `AgentGraphRunner.run` in line with `Runner.run` (narrowed in #165) and matches the JS `AgentGraphRunner` interface in `feat/next-ai-release`, which already accepts `string`. The spec is updated in parallel in [sdk-specs#164](https://github.com/launchdarkly/sdk-specs/pull/164).

## Changes

- `packages/sdk/server-ai/src/ldai/providers/agent_graph_runner.py` — protocol declares `run(input: str)`; dropped unused `Any` import.
- `packages/sdk/server-ai/src/ldai/managed_agent_graph.py` — `ManagedAgentGraph.run(input: str)` to match the underlying runner; dropped unused `Any` import.
- `packages/ai-providers/server-ai-openai/src/ldai_openai/openai_agent_graph_runner.py` — narrowed `run` signature; removed redundant `str(input)` coercion.
- `packages/ai-providers/server-ai-langchain/src/ldai_langchain/langgraph_agent_graph_runner.py` — narrowed `run` signature; removed redundant `str(input)` coercion in `HumanMessage` construction.

## BREAKING CHANGE

`AgentGraphRunner.run(input: Any)` is now `AgentGraphRunner.run(input: str)`. `ManagedAgentGraph.run(input: Any)` is now `ManagedAgentGraph.run(input: str)`. Callers passing non-string inputs must coerce to `str` at the call site.

## Test plan

- [x] `make test` — 329 tests pass across server-ai, server-ai-langchain, server-ai-openai
- [x] `make lint` — mypy, isort, pycodestyle clean across all three packages
- [ ] CI pipeline green on draft PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a breaking API change that will require downstream callers passing non-string inputs to update, but runtime behavior changes are minimal (removal of implicit `str()` coercion).
> 
> **Overview**
> Narrows the agent-graph execution API to accept only string prompts by changing `AgentGraphRunner.run` and `ManagedAgentGraph.run` from `input: Any` to `input: str`.
> 
> Updates the OpenAI and LangGraph runner implementations to match the new signature and removes redundant `str(input)` coercions when constructing messages / invoking `Runner.run`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d669bbe72bba7217b00975d90a60a8c2ad5d9497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->