### PR TITLE
ci: auto-bump provider package server-ai dep on release

### DIFF
--- a/packages/ai-providers/server-ai-langchain/pyproject.toml
+++ b/packages/ai-providers/server-ai-langchain/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "launchdarkly-server-sdk-ai>=0.19.0",
+    "launchdarkly-server-sdk-ai>=0.20.0", # x-release-please-version
     "langchain-core>=1.0.0",
     "langchain>=1.0.0",
 ]

--- a/packages/ai-providers/server-ai-openai/pyproject.toml
+++ b/packages/ai-providers/server-ai-openai/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
-    "launchdarkly-server-sdk-ai>=0.19.0",
+    "launchdarkly-server-sdk-ai>=0.20.0", # x-release-please-version
     "openai>=1.0.0",
 ]
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,9 @@
       "include-v-in-tag": false,
       "extra-files": [
         "src/ldai/__init__.py",
-        "PROVENANCE.md"
+        "PROVENANCE.md",
+        "/packages/ai-providers/server-ai-langchain/pyproject.toml",
+        "/packages/ai-providers/server-ai-openai/pyproject.toml"
       ],
       "component": "launchdarkly-server-sdk-ai"
     },


### PR DESCRIPTION
## The bug

The langchain and openai provider packages declare a hard dependency lower bound on `launchdarkly-server-sdk-ai` that is allowed to drift below the actual minimum version they require. As of provider versions **langchain 0.7.0** and **openai 0.6.0** (queued in the open release-please PR #171), both packages import `AIGraphMetrics` from `ldai.providers.types` — a symbol that **only exists in `launchdarkly-server-sdk-ai >=0.20.0`** (it was renamed from `GraphMetrics` in that release).

But both `pyproject.toml` files still declare `launchdarkly-server-sdk-ai>=0.19.0`. A consumer who installs the provider against server-ai 0.19.0 will hit `ImportError` at runtime.

This is a chronic risk: every breaking change in server-ai means the provider lower bounds need to be bumped manually. We want release-please to handle that automatically so we stop forgetting.

## The fix

Two coordinated changes:

### 1. Auto-bump on every server-ai release (release-please config)

Add the provider `pyproject.toml` files to the **server-ai package's** `extra-files` in `release-please-config.json`, using leading-`/` (repo-root absolute) paths:

```json
"extra-files": [
  "src/ldai/__init__.py",
  "PROVENANCE.md",
  "/packages/ai-providers/server-ai-langchain/pyproject.toml",
  "/packages/ai-providers/server-ai-openai/pyproject.toml"
]
```

Combined with an inline `# x-release-please-version` annotation on the dependency line in each provider `pyproject.toml`:

```toml
"launchdarkly-server-sdk-ai>=0.20.0", # x-release-please-version
```

…release-please's [Generic updater](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files) will rewrite the semver-looking value on that line to the new server-ai version each time the server-ai package is released — without disturbing anything else in the file. (The TOML parser sees the `#` comment as a no-op trailing comment on the array element; verified that the file still parses cleanly.)

This is the minimum-impact configuration: no plugins added, no workflow changes, no restructuring of the existing release flow. The `linked-versions` plugin is the wrong tool here because it forces the linked components to share a version — we want each provider to keep its own version history and just track the most-recent server-ai release in its lower bound.

### 2. Manual bump from `>=0.19.0` → `>=0.20.0`

Release-please will only auto-bump on **future** server-ai releases. The currently-open release PR #171 already cuts server-ai 0.20.0, langchain 0.7.0, and openai 0.6.0 — but it does not touch the dep lower bound (the auto-bump isn't configured yet). So the immediate broken bound has to be fixed by hand in this PR.

After this PR merges, release-please will regenerate PR #171, and **future** server-ai releases will pick up the new auto-bump behaviour for free.

## Verification

- [x] `make lint` passes (server-ai, langchain, openai)
- [x] Both provider `pyproject.toml` files still parse with `tomllib`; the annotation comment is invisible to the TOML parser.
- [x] Locally simulated the Generic updater against the modified langchain/openai `pyproject.toml` files using release-please 17.6.0 (the version bundled with `release-please-action@v5.0.0`) — confirmed that a server-ai bump from 0.20.0 → 0.21.0 rewrites the dep line to `>=0.21.0` and a 0.20.0 → 1.0.0 bump rewrites it to `>=1.0.0`, leaving the rest of the file untouched.

## Test plan

- [ ] Reviewer: glance at `release-please-config.json` and the two annotated dep lines.
- [ ] After merge: confirm release-please regenerates PR #171 and the provider `pyproject.toml` lower bounds remain `>=0.20.0` (no regression) — the auto-bump only fires on the **next** server-ai release after #171 ships.
- [ ] Future server-ai release: verify the corresponding release PR includes a diff to both provider `pyproject.toml` dep lines bumping the lower bound.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: release/packaging config-only changes that tighten dependency constraints and adjust release-please file updating, with no runtime logic changes.
> 
> **Overview**
> Updates the LangChain and OpenAI provider `pyproject.toml` files to require `launchdarkly-server-sdk-ai>=0.20.0` and annotates the line with `# x-release-please-version` so it can be rewritten automatically.
> 
> Extends `release-please-config.json` for `packages/sdk/server-ai` to treat both provider `pyproject.toml` files as `extra-files`, ensuring future server-ai releases bump the providers’ minimum dependency in generated release PRs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2782b120e9ac66cfa81f0abf303179bf202f595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->