### PR TITLE
feat!: Clean up async usage across SDK

### DIFF
--- a/packages/ai-providers/server-ai-langchain/README.md
+++ b/packages/ai-providers/server-ai-langchain/README.md
@@ -48,7 +48,7 @@ context = Context.builder("user-123").build()
 
 async def main():
     # Create a ManagedModel backed by the LangChain provider
-    model = await ai_client.create_model(
+    model = ai_client.create_model(
         "ai-config-key",
         context,
         AICompletionConfigDefault(
@@ -74,7 +74,7 @@ LaunchDarkly AI config flag, selects the LangChain runner automatically, and
 returns a `ManagedModel` that wraps the runner:
 
 ```python
-model = await ai_client.create_model("ai-config-key", context)
+model = ai_client.create_model("ai-config-key", context)
 
 if model:
     result = await model.run("What is feature flagging?")
@@ -121,7 +121,7 @@ print(result.parsed)  # {"sentiment": "positive", "confidence": 0.95}
 `LDAIConfigTracker`. For manual tracking, use the tracker directly:
 
 ```python
-model = await ai_client.create_model("ai-config-key", context)
+model = ai_client.create_model("ai-config-key", context)
 
 if model:
     result = await model.run("Explain feature flags.")

--- a/packages/ai-providers/server-ai-openai/README.md
+++ b/packages/ai-providers/server-ai-openai/README.md
@@ -35,7 +35,7 @@ context = Context.builder("user-123").build()
 
 async def main():
     # Create a ManagedModel backed by the OpenAI provider
-    model = await ai_client.create_model(
+    model = ai_client.create_model(
         "ai-config-key",
         context,
         AICompletionConfigDefault(
@@ -61,7 +61,7 @@ LaunchDarkly AI config flag, selects the OpenAI runner automatically, and
 returns a `ManagedModel` that wraps the runner:
 
 ```python
-model = await ai_client.create_model("ai-config-key", context)
+model = ai_client.create_model("ai-config-key", context)
 
 if model:
     result = await model.run("What is feature flagging?")
@@ -107,7 +107,7 @@ print(result.parsed)  # {"sentiment": "positive", "confidence": 0.95}
 `LDAIConfigTracker`. For manual tracking, use the tracker directly:
 
 ```python
-model = await ai_client.create_model("ai-config-key", context)
+model = ai_client.create_model("ai-config-key", context)
 
 if model:
     result = await model.run("Explain feature flags.")

--- a/packages/sdk/server-ai/README.md
+++ b/packages/sdk/server-ai/README.md
@@ -115,7 +115,7 @@ from ldai import LDAIClient, AICompletionConfigDefault, ModelConfig, LDMessage
 # Use the same default_config from the retrieval section above
 async def main():
     context = Context.create("user-123")
-    model = await ai_client.create_model(
+    model = ai_client.create_model(
         'customer-support-chat',
         context,
         default_config,

--- a/packages/sdk/server-ai/pyproject.toml
+++ b/packages/sdk/server-ai/pyproject.toml
@@ -67,6 +67,7 @@ non_interactive = true
 [tool.pytest.ini_options]
 addopts = ["-ra"]
 testpaths = ["tests"]
+asyncio_mode = "strict"
 
 [tool.isort]
 profile = "black"

--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -383,7 +383,7 @@ class LDAIClient:
                 judge_instances.append(judge)
         return Evaluator(judge_instances)
 
-    async def create_model(
+    def create_model(
         self,
         key: str,
         context: Context,
@@ -404,7 +404,7 @@ class LDAIClient:
 
         Example::
 
-            model = await client.create_model(
+            model = client.create_model(
                 "customer-support-chat",
                 context,
                 AICompletionConfigDefault(
@@ -435,7 +435,7 @@ class LDAIClient:
 
         return ManagedModel(config, runner)
 
-    async def create_agent(
+    def create_agent(
         self,
         key: str,
         context: Context,
@@ -463,7 +463,7 @@ class LDAIClient:
 
         Example::
 
-            agent = await client.create_agent(
+            agent = client.create_agent(
                 "customer-support-agent",
                 context,
                 tools={"get-order": fetch_order_fn},
@@ -722,7 +722,7 @@ class LDAIClient:
             create_tracker=graph_tracker_factory,
         )
 
-    async def create_agent_graph(
+    def create_agent_graph(
         self,
         key: str,
         context: Context,
@@ -748,7 +748,7 @@ class LDAIClient:
 
         Example::
 
-            graph = await client.create_agent_graph(
+            graph = client.create_agent_graph(
                 "travel-assistant-graph",
                 context,
                 tools={

--- a/packages/sdk/server-ai/src/ldai/evaluator.py
+++ b/packages/sdk/server-ai/src/ldai/evaluator.py
@@ -40,9 +40,9 @@ class Evaluator:
         """
         Run all configured judges against the given input/output pair.
 
-        Schedules the judge evaluations as an asyncio Task and returns it
-        immediately. The caller can await the task to get results or pass it
-        to tracking helpers.
+        The returned Task starts judge evaluations immediately. The caller
+        must retain a reference to the results until it resolves to ensure
+        Judge evaluations are completed.
 
         :param input_text: The input that was provided to the AI model
         :param output_text: The AI-generated output to evaluate

--- a/packages/sdk/server-ai/src/ldai/managed_agent.py
+++ b/packages/sdk/server-ai/src/ldai/managed_agent.py
@@ -45,7 +45,7 @@ class ManagedAgent:
             lambda: self._agent_runner.run(input),
         )
 
-        evaluations_task = self._track_judge_results(tracker, input, result.content)
+        evaluations_task = await self._track_judge_results(tracker, input, result.content)
 
         return ManagedResult(
             content=result.content,
@@ -54,7 +54,7 @@ class ManagedAgent:
             evaluations=evaluations_task,
         )
 
-    def _track_judge_results(
+    async def _track_judge_results(
         self,
         tracker: LDAIConfigTracker,
         input_text: str,

--- a/packages/sdk/server-ai/src/ldai/managed_model.py
+++ b/packages/sdk/server-ai/src/ldai/managed_model.py
@@ -44,7 +44,7 @@ class ManagedModel:
             lambda: self._model_runner.run(prompt),
         )
 
-        evaluations_task = self._track_judge_results(tracker, prompt, result.content)
+        evaluations_task = await self._track_judge_results(tracker, prompt, result.content)
 
         return ManagedResult(
             content=result.content,
@@ -54,7 +54,7 @@ class ManagedModel:
             evaluations=evaluations_task,
         )
 
-    def _track_judge_results(
+    async def _track_judge_results(
         self,
         tracker: LDAIConfigTracker,
         input_text: str,

--- a/packages/sdk/server-ai/tests/test_managed_agent.py
+++ b/packages/sdk/server-ai/tests/test_managed_agent.py
@@ -310,16 +310,14 @@ class TestManagedAgentEvaluations:
 class TestLDAIClientCreateAgent:
     """Tests for LDAIClient.create_agent."""
 
-    @pytest.mark.asyncio
-    async def test_returns_none_when_agent_is_disabled(self, ldai_client: LDAIClient):
+    def test_returns_none_when_agent_is_disabled(self, ldai_client: LDAIClient):
         """Should return None when agent config is disabled."""
         context = Context.create('user-key')
-        result = await ldai_client.create_agent('disabled-agent', context)
+        result = ldai_client.create_agent('disabled-agent', context)
 
         assert result is None
 
-    @pytest.mark.asyncio
-    async def test_returns_none_when_provider_unavailable(self, ldai_client: LDAIClient):
+    def test_returns_none_when_provider_unavailable(self, ldai_client: LDAIClient):
         """Should return None when no AI provider is available."""
         import ldai.providers.runner_factory as rf
         context = Context.create('user-key')
@@ -327,13 +325,12 @@ class TestLDAIClientCreateAgent:
         original = rf.RunnerFactory.create_agent
         rf.RunnerFactory.create_agent = MagicMock(return_value=None)
         try:
-            result = await ldai_client.create_agent('customer-support-agent', context)
+            result = ldai_client.create_agent('customer-support-agent', context)
             assert result is None
         finally:
             rf.RunnerFactory.create_agent = original
 
-    @pytest.mark.asyncio
-    async def test_returns_managed_agent_when_runner_available(self, ldai_client: LDAIClient):
+    def test_returns_managed_agent_when_runner_available(self, ldai_client: LDAIClient):
         """Should return ManagedAgent when runner is successfully created."""
         import ldai.providers.runner_factory as rf
         context = Context.create('user-key')
@@ -346,7 +343,7 @@ class TestLDAIClientCreateAgent:
         original = rf.RunnerFactory.create_agent
         rf.RunnerFactory.create_agent = MagicMock(return_value=mock_runner)
         try:
-            result = await ldai_client.create_agent('customer-support-agent', context)
+            result = ldai_client.create_agent('customer-support-agent', context)
             assert isinstance(result, ManagedAgent)
             assert result.get_agent_runner() is mock_runner
         finally:

--- a/packages/sdk/server-ai/tests/test_managed_agent_graph.py
+++ b/packages/sdk/server-ai/tests/test_managed_agent_graph.py
@@ -303,7 +303,7 @@ async def test_create_agent_graph_returns_managed_agent_graph(ldai_client: LDAIC
         'ldai.providers.runner_factory.RunnerFactory.create_agent_graph',
         new=MagicMock(return_value=stub_runner),
     ):
-        managed = await ldai_client.create_agent_graph('travel-graph', context)
+        managed = ldai_client.create_agent_graph('travel-graph', context)
 
     assert managed is not None
     assert isinstance(managed, ManagedAgentGraph)
@@ -313,7 +313,7 @@ async def test_create_agent_graph_returns_managed_agent_graph(ldai_client: LDAIC
 @pytest.mark.asyncio
 async def test_create_agent_graph_returns_none_when_disabled(ldai_client: LDAIClient):
     context = Context.create('user-key')
-    managed = await ldai_client.create_agent_graph('disabled-graph', context)
+    managed = ldai_client.create_agent_graph('disabled-graph', context)
     assert managed is None
 
 
@@ -325,7 +325,7 @@ async def test_create_agent_graph_returns_none_when_runner_factory_fails(ldai_cl
         'ldai.providers.runner_factory.RunnerFactory.create_agent_graph',
         new=MagicMock(return_value=None),
     ):
-        managed = await ldai_client.create_agent_graph('travel-graph', context)
+        managed = ldai_client.create_agent_graph('travel-graph', context)
 
     assert managed is None
 
@@ -344,7 +344,7 @@ async def test_create_agent_graph_passes_tools_to_factory(ldai_client: LDAIClien
         'ldai.providers.runner_factory.RunnerFactory.create_agent_graph',
         new=fake_create_agent_graph,
     ):
-        await ldai_client.create_agent_graph('travel-graph', context, tools=tools)
+        ldai_client.create_agent_graph('travel-graph', context, tools=tools)
 
     assert captured['tools'] is tools
 
@@ -357,7 +357,7 @@ async def test_create_agent_graph_run_produces_result(ldai_client: LDAIClient):
         'ldai.providers.runner_factory.RunnerFactory.create_agent_graph',
         new=MagicMock(return_value=StubAgentGraphRunner("final answer")),
     ):
-        managed = await ldai_client.create_agent_graph('travel-graph', context)
+        managed = ldai_client.create_agent_graph('travel-graph', context)
 
     assert managed is not None
     result = await managed.run("find restaurants")


### PR DESCRIPTION
## Summary

Five small async-hygiene cleanups, surfaced by a recent code review:

- Drop `async` from `LDAIClient.create_model`, `create_agent`, and `create_agent_graph` — they did no async work, just sync evaluation, sync tracking, sync factory calls, and a sync constructor.
- Mark `ManagedModel._track_judge_results` and `ManagedAgent._track_judge_results` as `async` to document that they require a running event loop (they construct an `asyncio.Task`).
- Tighten the `Evaluator.evaluate` docstring to warn about the Task-lifecycle hazard: asyncio holds only a weak reference, so the caller must retain a strong reference until the Task completes.
- Pin `asyncio_mode = "strict"` in `pyproject.toml` so a future async test missing `@pytest.mark.asyncio` fails loudly rather than silently auto-detecting.

## Breaking Changes

`LDAIClient.create_model`, `create_agent`, and `create_agent_graph` are no longer coroutines. Callers should remove `await` from the factory call. The `run()` method on the returned `ManagedModel` / `ManagedAgent` / `ManagedAgentGraph` is still async.

Before:

```python
model = await ai_client.create_model("key", context, default_config)
if model:
    response = await model.run("hi")
```

After:

```python
model = ai_client.create_model("key", context, default_config)
if model:
    response = await model.run("hi")
```

feat!: Make AI config factory methods synchronous

## Test plan

- [x] `make test-server-ai` passes (203 tests)
- [x] `make test-langchain` and `make test-openai` pass (46 tests)
- [x] `make lint` passes for all packages (mypy, isort, pycodestyle)
- [x] `asyncio_mode = "strict"` confirmed: existing `@pytest.mark.asyncio`-marked tests still collect and run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a breaking API change (`create_model`/`create_agent`/`create_agent_graph` are no longer awaitable) and adjusts async task/pytest behavior, which could surface integration and test failures for downstream users.
> 
> **Overview**
> **Makes AI factory creation APIs synchronous.** `LDAIClient.create_model`, `create_agent`, and `create_agent_graph` drop `async`/`await` since they perform no async work, and docs/tests/README examples are updated to remove `await` on these calls (while leaving `run()` async).
> 
> **Tightens async evaluation/task handling.** Judge-evaluation tracking helpers in `ManagedModel`/`ManagedAgent` are marked `async` and awaited, `Evaluator.evaluate` documentation now warns callers to retain the returned `asyncio.Task`, and `pytest` is configured with `asyncio_mode = "strict"` to prevent unmarked async tests from silently passing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a7dc0819c7c50819a814fd6c2f4a9b198270d13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->