### PR TITLE
chore: Allow 1.0 release

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
     "packages/sdk/server-ai": {
       "release-type": "python",
       "versioning": "default",
-      "bump-minor-pre-major": true,
       "include-v-in-tag": false,
       "extra-files": [
         "src/ldai/__init__.py",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk config-only change that adjusts release-please version bump behavior for `packages/sdk/server-ai` to allow a 1.0 release; no runtime code paths are affected.
> 
> **Overview**
> Updates `release-please-config.json` to remove `bump-minor-pre-major` for `packages/sdk/server-ai`, allowing release-please to cut a `1.0` major release for that package instead of forcing minor bumps while `<1.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47c8d82ea62a34b0e7ef13f2a04e4333770a12a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->