### PR TITLE
fix: Remove pre-release caution note from server-ai README

### DIFF
--- a/packages/sdk/server-ai/README.md
+++ b/packages/sdk/server-ai/README.md
@@ -8,12 +8,6 @@
 
 This package contains the LaunchDarkly Server-Side AI SDK for Python (`launchdarkly-server-sdk-ai`).
 
-> [!CAUTION]
-> This SDK is in pre-release and not subject to backwards compatibility
-> guarantees. The API may change based on feedback.
->
-> Pin to a specific minor version and review the [changelog](CHANGELOG.md) before upgrading.
-
 ## LaunchDarkly overview
 
 [LaunchDarkly](https://www.launchdarkly.com) is a feature management platform that serves over 100 billion feature flags daily to help teams build better software, faster. [Get started](https://docs.launchdarkly.com/home/getting-started) using LaunchDarkly today!

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
     "packages/sdk/server-ai": {
       "release-type": "python",
       "versioning": "default",
-      "bump-minor-pre-major": true,
       "include-v-in-tag": false,
       "extra-files": [
         "src/ldai/__init__.py",


### PR DESCRIPTION
Tracking internally: AIC-1655

Removes the pre-release caution banner from `launchdarkly-server-sdk-ai` now that the SDK has hit 1.0. Provider package READMEs retain the note as those packages are still pre-release.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change; removes a pre-release warning banner with no code or behavior impact.
> 
> **Overview**
> Removes the pre-release *caution* banner and upgrade pinning guidance from the `packages/sdk/server-ai/README.md`, reflecting that `launchdarkly-server-sdk-ai` is no longer positioned as pre-release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880818a3174d8b86474410603c96d836177455bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->