### PR TITLE
chore: Remove dead install_types mypy config

### DIFF
--- a/packages/ai-providers/server-ai-langchain/pyproject.toml
+++ b/packages/ai-providers/server-ai-langchain/pyproject.toml
@@ -53,8 +53,6 @@ packages = ["src/ldai_langchain"]
 [tool.mypy]
 python_version = "3.10"
 ignore_missing_imports = true
-install_types = true
-non_interactive = true
 
 [tool.isort]
 profile = "black"

--- a/packages/ai-providers/server-ai-openai/pyproject.toml
+++ b/packages/ai-providers/server-ai-openai/pyproject.toml
@@ -52,8 +52,6 @@ packages = ["src/ldai_openai"]
 [tool.mypy]
 python_version = "3.10"
 ignore_missing_imports = true
-install_types = true
-non_interactive = true
 
 [tool.isort]
 profile = "black"

--- a/packages/sdk/server-ai/pyproject.toml
+++ b/packages/sdk/server-ai/pyproject.toml
@@ -61,8 +61,6 @@ packages = ["src/ldai"]
 [tool.mypy]
 python_version = "3.10"
 ignore_missing_imports = true
-install_types = true
-non_interactive = true
 
 [tool.pytest.ini_options]
 addopts = ["-ra"]


### PR DESCRIPTION
## Summary

- Removes `install_types = true` and `non_interactive = true` from the `[tool.mypy]` section in all three package `pyproject.toml` files (`server-ai`, `server-ai-openai`, `server-ai-langchain`).
- These settings were inherited from the Poetry era. Poetry venvs include `pip`, so mypy's `install_types` mechanism could auto-install missing type stubs via `python -m pip install`. After the migration to uv (PR #101), uv-managed venvs do not include `pip`, making these settings a silent no-op.
- The AI SDK packages don't import any untyped third-party packages — `launchdarkly-server-sdk`, `chevron`, `langchain`, and `openai` all ship their own type information — so no explicit stubs need to be added; the settings can simply be removed.

## Test plan

- [x] `make lint` passes in `packages/sdk/server-ai` with no mypy errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only cleanup with no runtime or typing behavior change beyond removing ineffective mypy flags.
> 
> **Overview**
> Removes **`install_types = true`** and **`non_interactive = true`** from **`[tool.mypy]`** in `packages/sdk/server-ai`, `packages/ai-providers/server-ai-openai`, and `packages/ai-providers/server-ai-langchain`.
> 
> Those flags only auto-installed missing stubs when mypy could run **`pip`** in the active venv. After the move to **uv**, venvs typically lack pip, so the options did nothing. **`python_version`** and **`ignore_missing_imports`** are unchanged; third-party deps in these packages already ship types, so no stub replacements were added.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b04b0c9711ba1e7f6a6d6c732d562ecac8a943. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->