### PR TITLE
feat: Add region property to ModelConfig

### DIFF
--- a/packages/sdk/server-ai/src/ldai/client.py
+++ b/packages/sdk/server-ai/src/ldai/client.py
@@ -832,10 +832,12 @@ class LDAIClient:
         if 'model' in variation and isinstance(variation['model'], dict):
             parameters = variation['model'].get('parameters', None)
             custom = variation['model'].get('custom', None)
+            region = variation['model'].get('region', None)
             model = ModelConfig(
                 name=variation['model']['name'],
                 parameters=parameters,
-                custom=custom
+                custom=custom,
+                region=region,
             )
 
         variation_key = variation.get('_ldMeta', {}).get('variationKey', '')

--- a/packages/sdk/server-ai/src/ldai/models.py
+++ b/packages/sdk/server-ai/src/ldai/models.py
@@ -52,15 +52,17 @@ class ModelConfig:
     Configuration related to the model.
     """
 
-    def __init__(self, name: str, parameters: Optional[Dict[str, Any]] = None, custom: Optional[Dict[str, Any]] = None):
+    def __init__(self, name: str, parameters: Optional[Dict[str, Any]] = None, custom: Optional[Dict[str, Any]] = None, region: Optional[str] = None):
         """
         :param name: The name of the model.
         :param parameters: Additional model-specific parameters.
         :param custom: Additional customer provided data.
+        :param region: The region the model is deployed in.
         """
         self._name = name
         self._parameters = parameters
         self._custom = custom
+        self._region = region
 
     @property
     def name(self) -> str:
@@ -93,6 +95,13 @@ class ModelConfig:
 
         return self._custom.get(key)
 
+    @property
+    def region(self) -> Optional[str]:
+        """
+        The region the model is deployed in.
+        """
+        return self._region
+
     def to_dict(self) -> dict:
         """
         Render the given model config as a dictionary object.
@@ -101,6 +110,7 @@ class ModelConfig:
             'name': self._name,
             'parameters': self._parameters,
             'custom': self._custom,
+            'region': self._region,
         }
 
 

--- a/packages/sdk/server-ai/src/ldai/models.py
+++ b/packages/sdk/server-ai/src/ldai/models.py
@@ -52,7 +52,13 @@ class ModelConfig:
     Configuration related to the model.
     """
 
-    def __init__(self, name: str, parameters: Optional[Dict[str, Any]] = None, custom: Optional[Dict[str, Any]] = None, region: Optional[str] = None):
+    def __init__(
+        self,
+        name: str,
+        parameters: Optional[Dict[str, Any]] = None,
+        custom: Optional[Dict[str, Any]] = None,
+        region: Optional[str] = None,
+    ):
         """
         :param name: The name of the model.
         :param parameters: Additional model-specific parameters.

--- a/packages/sdk/server-ai/tests/test_model_config.py
+++ b/packages/sdk/server-ai/tests/test_model_config.py
@@ -32,6 +32,23 @@ def td() -> TestData:
     )
 
     td.update(
+        td.flag('model-config-with-region')
+        .variations(
+            {
+                'model': {
+                    'name': 'anthropic.claude-opus-4-7',
+                    'parameters': {},
+                    'region': 'us',
+                },
+                'provider': {'name': 'Bedrock'},
+                'messages': [{'role': 'system', 'content': 'Hello!'}],
+                '_ldMeta': {'enabled': True, 'variationKey': 'us-variation', 'version': 1},
+            },
+        )
+        .variation_for_all(0)
+    )
+
+    td.update(
         td.flag('multiple-messages')
         .variations(
             {
@@ -480,6 +497,36 @@ def test_create_tracker_preserves_config_metadata():
     assert track_data['modelName'] == 'gpt-4'
     assert track_data['providerName'] == 'openai'
     assert 'runId' in track_data
+
+
+def test_model_config_region():
+    model = ModelConfig('fakeModel', region='us')
+    assert model.region == 'us'
+
+
+def test_model_config_region_defaults_to_none():
+    model = ModelConfig('fakeModel')
+    assert model.region is None
+
+
+def test_model_config_region_from_flag(ldai_client: LDAIClient):
+    context = Context.create('user-key')
+    default = AICompletionConfigDefault(enabled=True, model=ModelConfig('fake-model'), messages=[])
+
+    config = ldai_client.completion_config('model-config-with-region', context, default)
+
+    assert config.model is not None
+    assert config.model.region == 'us'
+
+
+def test_model_config_no_region_is_none(ldai_client: LDAIClient):
+    context = Context.create('user-key')
+    default = AICompletionConfigDefault(enabled=True, model=ModelConfig('fake-model'), messages=[])
+
+    config = ldai_client.completion_config('model-config', context, default)
+
+    assert config.model is not None
+    assert config.model.region is None
 
 
 def test_create_tracker_each_call_has_different_run_id():


### PR DESCRIPTION
BEGIN_COMMIT_OVERRIDE
feat: Add region property to ModelConfig
END_COMMIT_OVERRIDE

**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

https://launchdarkly.atlassian.net/jira/software/c/projects/AIC/boards/2045?selectedIssue=AIC-2689

**Describe the solution you've provided**

Adds the `region` property to the `ModelConfig` object

**Additional context**

Some model providers, namely Bedrock, require including a `region` field on a given call. A call for a sonnet model might look like: `global.anthropic.sonnet-4-7` or `us.anthropic.sonnet-4-7` etc.

This field was added on the UI for Bedrock models and is optionally includable. Users would be expected to prepend their region to their model names if they're using a provider that requires it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Backward-compatible optional field on model config parsing with no changes to auth or provider call paths in this diff.
> 
> **Overview**
> Adds optional **`region`** on **`ModelConfig`** so AI Config flag variations can carry deployment region (e.g. Bedrock `us` vs `global`) without encoding it only in the model name.
> 
> **`LDAIClient`** now reads `model.region` from evaluated variations when building completion/agent/judge configs, and **`to_dict()`** includes **`region`** for round-tripping. Omitted **`region`** stays **`None`**, so existing flags behave unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219f71b80d981ccefe88ba75ad14713713f06d88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->