### PR TITLE
chore: sets x-release-please-version for optimizations

### DIFF
--- a/packages/optimization/src/ldai_optimizer/__init__.py
+++ b/packages/optimization/src/ldai_optimizer/__init__.py
@@ -22,7 +22,7 @@ from ldai_optimizer.dataclasses import (
 )
 from ldai_optimizer.ld_api_client import LDApiError
 
-__version__ = "0.1.0"
+__version__ = "0.1.0"  # x-release-please-version
 
 __all__ = [
     '__version__',


### PR DESCRIPTION
**Requirements**

- [ ] I have added test coverage for new or changed functionality
- [ ] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

Missed x-release-please-version for initial release. This adds it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only release tooling change; version value unchanged.
> 
> **Overview**
> Adds the `# x-release-please-version` marker on `__version__` in `ldai_optimizer/__init__.py`, matching `pyproject.toml` and other packages (e.g. `ldai`). **No runtime behavior change**—release-please can now keep the package’s public version string in sync on release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c737b6a4fdd12eda543d894e306b0343e8a9395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->